### PR TITLE
[issue-26] Remove extra slash between the domain name and the relative UR

### DIFF
--- a/lib/awestruct/extensions/disqus.rb
+++ b/lib/awestruct/extensions/disqus.rb
@@ -14,7 +14,7 @@ module Awestruct
             <div id="disqus_thread"></div>
             <script type="text/javascript">
             var disqus_shortname = '#{site.disqus}';
-            var disqus_url = "#{site.base_url}/#{self.url}";
+            var disqus_url = "#{site.base_url}#{self.url}";
             #{developer}
             #{identifier}
             (function() {


### PR DESCRIPTION
Fix for https://github.com/bobmcwhirter/awestruct/issues/26

Note that users of the buggy disqus extension will see their comments unassociated with their old page as the URL is sued as unique id by default.

That being said, the service was half broken anyways. We'll need to put a warning in the release notes
