### PR TITLE
Adding the gsub transformer

### DIFF
--- a/lib/awestruct/extensions/gsub.rb
+++ b/lib/awestruct/extensions/gsub.rb
@@ -1,0 +1,19 @@
+
+module Awestruct
+  module Extensions
+    class Gsub      
+      def initialize(pattern, replacement, options = {})
+        @pattern = pattern
+        @replacement = replacement
+        @gsub_required = options[:gsub_required] || lambda { |site, page| page.output_path.end_with?(".html") }
+      end
+      
+      def transform(site, page, rendered)
+        if (@gsub_required.call(site, page))
+          rendered = rendered.gsub(@pattern, @replacement)
+        end
+        rendered
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adding the gsub transformer which allows a global regular expression replacement on rendered pages.
# Example of use for syntax highlighting

Configured in `pipeline.rb` like this:

```
transformer Awestruct::Extensions::Gsub.new(
    /\<!--\s*lang:\s*java\s*--\>\s*<pre><code>(.*?)<\/code><\/pre>/, 
    "<pre class=\"brush: java\">\\1</pre>")
```

Then markdown code blocks with a preceeding HTML comment hinting the language:

```
<!-- lang: java -->
    public static void main(String[] args) {
        // blah
    }
```

Would be transformed to HTML like this:

```
<pre class="brush: java">
    public static void main(String[] args) {
        // blah
    }
</pre>
```

which is the markup required by our syntax highlighter. Doing it like this means that we can let Markdown worry about HTML escaping the example code for us, and also we can have examples from multiple languages in a document (not the case if you configured the highlighter to operate on all `<pre><code>` elements).
