### PR TITLE
Add support in Posts to read page.date as a alternative to relative_source_path

### DIFF
--- a/lib/awestruct/extensions/posts.rb
+++ b/lib/awestruct/extensions/posts.rb
@@ -12,26 +12,45 @@ module Awestruct
         posts = []
 
         site.pages.each do |page|
-          if ( page.relative_source_path =~ /^#{@path_prefix}\/(20[01][0-9])-([01][0-9])-([0123][0-9])-([^.]+)\..*$/ )
-            year  = $1
-            month = $2
-            day   = $3
-            slug  = $4
-            page.date = Time.utc( year.to_i, month.to_i, day.to_i )
-            page.slug = slug
-            context = OpenStruct.new({
-              :site=>site,
-              :page=>page,
-            })
-            #page.body = page.render( context )
-            page.output_path = "#{@path_prefix}/#{year}/#{month}/#{day}/#{slug}.html"
-            #page.layout = 'post'
-            posts << page
+          year, month, day, slug = nil
+
+          if ( page.relative_source_path =~ /^#{@path_prefix}\// )
+            if ( page.relative_source_path =~ /^#{@path_prefix}\/(20[01][0-9])-([01][0-9])-([0123][0-9])-([^.]+)\..*$/ )
+              year  = $1
+              month = $2
+              day   = $3
+              slug  = $4
+              page.date = Time.utc( year.to_i, month.to_i, day.to_i )
+            elsif (page.date)
+              page.relative_source_path =~ /^#{@path_prefix}\/(.*)\..*$/
+              date = page.date;
+              if date.kind_of? String
+                date = Time.parse page.date
+              end
+              year = date.year
+              month = date.month
+              day = date.day
+              page.date = Time.utc(year, month, day)
+              slug = $1
+            end
+
+            # if a date was found create a post
+            if( year and month and day)
+              page.slug = slug
+              context = OpenStruct.new({
+                :site=>site,
+                :page=>page,
+              })
+              #page.body = page.render( context )
+              page.output_path = "#{@path_prefix}/#{year}/#{month}/#{day}/#{slug}.html"
+              #page.layout = 'post'
+              posts << page
+            end
           end
         end
         
         posts = posts.sort_by{|each| [each.date, each.sequence || 0, File.mtime( each.source_path ), each.slug ] }.reverse
-        
+
         last = nil
         singular = @assign_to.to_s.singularize
         posts.each do |e|
@@ -41,7 +60,7 @@ module Awestruct
           end
           last = e
         end
-        
+
         site.send( "#{@assign_to}=", posts )
       end
     end


### PR DESCRIPTION
Add support in Posts to read page.date as a alternative to relative_source_path to extract year/month/day information.

e.g. files named:

2011-01-01-name.xx

are handled the same as

name.xx

---

  date: 2011-01-01

---
