### PR TITLE
optionally generate disqus post identifier from date & slug

### DIFF
--- a/lib/awestruct/extensions/disqus.rb
+++ b/lib/awestruct/extensions/disqus.rb
@@ -1,3 +1,5 @@
+require 'digest/sha1'
+
 module Awestruct
   module Extensions
     class Disqus
@@ -8,15 +10,17 @@ module Awestruct
 
       module Disqus
         def disqus_comments()
-          developer = (site.disqus_developer) ? 'var disqus_developer = 1;' : ''
-          identifier = (self.disqus_identifier) ? %Q{var disqus_identifier = "#{self.disqus_identifier}";} : ''
+          identifier = "null"
+          if self.disqus_identifier or site.disqus_generate_id
+            identifier = %Q("#{self.resolve_disqus_identifier()}")
+          end
           %Q{
             <div id="disqus_thread"></div>
             <script type="text/javascript">
             var disqus_shortname = '#{site.disqus}';
             var disqus_url = "#{site.base_url}#{self.url}";
-            #{developer}
-            #{identifier}
+            var disqus_developer = #{site.disqus_developer ? 1 : "null"};
+            var disqus_identifier = #{identifier};
             (function() {
               var dsq = document.createElement("script"); dsq.type = "text/javascript"; dsq.async = true;
               dsq.src = "http://#{site.disqus}.disqus.com/embed.js";
@@ -28,8 +32,11 @@ module Awestruct
         end
 
         def disqus_comments_link()
-          identifier = self.disqus_identifier ? %Q(data-disqus-identifier="#{self.disqus_identifier}") : ''
-          %Q{ <a href="#{self.url}#disqus_thread" #{identifier}>Comments</a> }
+          identifier = ''
+          if self.disqus_identifier or site.disqus_generate_id
+            identifier = %Q{ data-disqus-identifier="#{self.resolve_disqus_identifier()}"}
+          end
+          %Q{ <a href="#{self.url}#disqus_thread"#{identifier}>Comments</a> }
         end
 
         def disqus_comments_count()
@@ -43,6 +50,10 @@ module Awestruct
             }());
             </script>
           }
+        end
+
+        def resolve_disqus_identifier()
+          self.disqus_identifier ? self.disqus_identifier : Digest::SHA1.hexdigest(self.date.strftime('%Y-%m-%d-') + self.slug)
         end
       end
     end


### PR DESCRIPTION
Mimic the IntenseDebate extension by allowing the post identifier to be automatically generated. To retain backwards compatibility, the identifier is only generated if site.disqus_generate_id is true and an identifier was not assigned manually.

Also organized the html generation a bit.
