### PR TITLE
add support for custom rule functions in RedCloth

### DIFF
--- a/lib/awestruct/textilable.rb
+++ b/lib/awestruct/textilable.rb
@@ -4,7 +4,11 @@ module Awestruct
     def render(context)
       rendered = ''
       begin
-        rendered = RedCloth.new( context.interpolate_string( raw_page_content ) ).to_html
+        # a module of rule functions is included in RedCloth using RedCloth.send(:include, MyRules)
+        # rule functions on that module are activated by setting the property site.textile_rules
+        # ex. site.textile_rules = ['emoticons']
+        rules = context.site.textile_rules ? context.site.textile_rules.map { |r| r.to_sym } : []
+        rendered = RedCloth.new( context.interpolate_string( raw_page_content ) ).to_html(*rules)
       rescue => e
         puts e
         puts e.backtrace


### PR DESCRIPTION
Custom rule functions must be passed to the to_html method of the RedCloth object. Pass the method names defined by site.textile_rules to this method, first converting them to symbols (as required by RedCloth).

The functions must be included into the RedCloth class using an Awestruct Extension. For example:

```
module Awestruct::Extensions
  class TextilePlus
    def initialize()
      RedCloth.send(:include, CustomRules)
    end

    module CustomRules
      def emoticons(text)
         # replace emoticons in text
      end
    end
  end
end
```

You can either set site.textile_rules in this extension, or in _config/site.yml. Here's an example in site.yml:

```
textile_rules = [emoticons]
```
