### PR TITLE
Fix a bug where Awestruct doesn't render a file intermittently

### DIFF
--- a/lib/awestruct/engine.rb
+++ b/lib/awestruct/engine.rb
@@ -1,4 +1,3 @@
-
 require 'ostruct'
 require 'find'
 require 'compass'
@@ -214,8 +213,20 @@ module Awestruct
       now = Time.now
       generated_mtime = File.mtime( generated_path )
       return true if ( ( @max_site_mtime || Time.at(0) ) > generated_mtime )
-      source_mtime = File.mtime( page.source_path )
-      return true if ( source_mtime > generated_mtime ) && ( source_mtime + 1 < now )
+
+      while true
+        now = Time.now
+        source_mtime = File.mtime( page.source_path )
+        if ( now - source_mtime > 1 )
+          if ( source_mtime - generated_mtime >= 0 )
+            return true
+          else
+            break
+          end
+        end
+        sleep 0.1
+      end
+
       ext = page.output_extension
       layout_name = page.layout
       while ( ! layout_name.nil? )


### PR DESCRIPTION
Awestruct does not render a file which was modified less than 1~2 seconds ago, probably to avoid rendering an incompletely written file.  However, this prohibits a modified file from rendering when Awestruct detected the modified file very quickly (e.g. within 1 second.) 

To avoid this problem, it's better run a loop to wait for the file's mtime get old enough.  After the fix, I see Awestruct almost always picks the changes up correctly.

The only edge case is where a user modifies the file during generation, but a user can simply touch the file again.

I really wish this fix is included in the next release because I had to restart Awestruct or re-touch the modified files almost every time I make changes.  Maybe I'm saving too often, but it was driving me crazy. :-)
