### PR TITLE
remove unnecessary space in tag link which breaks styling

### DIFF
--- a/lib/awestruct/extensions/tag_cloud.html.haml
+++ b/lib/awestruct/extensions/tag_cloud.html.haml
@@ -4,5 +4,4 @@
 .tag-cloud
   - for tag in page.tags
     %span.tag{:class=>"tag-#{tag.group}"}
-      %a{:href=>tag.primary_page.url}
-        = tag.to_s
+      %a{:href=>tag.primary_page.url}= tag


### PR DESCRIPTION
Currently, the tag cloud outputs links as:

```
<a href="/blog/tags/announcement/">
  announcement
</a>
```

This patch consolidates that link to:

```
<a href="/blog/tags/announcement/">announcement</a>
```

This is much more friendly for styling.
