### PR TITLE
Fix a bug where has_pages?() always returns false

### DIFF
--- a/lib/awestruct/site.rb
+++ b/lib/awestruct/site.rb
@@ -25,7 +25,7 @@ module Awestruct
     end
 
     def has_page?(path)
-      ! pages.find{|e| e.path == path}.nil?
+      ! pages.find{|e| e.source_path == path}.nil?
     end
 
     def output_path(path, ext=nil)


### PR DESCRIPTION
`RenderableFile` does not have a property `path` but have `source path`, and thus `Site.has_pages?()` always returns false.
