### PR TITLE
support custom encoding for front_matter files; fixes: compensate for Hpricot encoding issues

### DIFF
--- a/lib/awestruct/context_helper.rb
+++ b/lib/awestruct/context_helper.rb
@@ -2,15 +2,15 @@ require 'hpricot'
 
 module Awestruct
   module ContextHelper
-    
+
     def html_to_text(str)
       str.gsub( /<[^>]+>/, '' ).gsub( /&nbsp;/, ' ' )
     end
- 
+
     def clean_html(str)
       str.gsub( /&nbsp;/, ' ' )
     end
-  
+
     def without_images(str)
       str.gsub(/<img[^>]+>/,'').gsub(/<a[^>]+>([^<]*)<\/a>/, '\1')
     end
@@ -49,7 +49,8 @@ module Awestruct
       doc.search( "//img" ).each do |img|
         img['src'] = fix_url( base_url, img['src'] )
       end
-      return doc.to_s
+      # Hpricot::Doc#to_s output encoding is not necessarily the same as the encoding of text
+      return doc.to_s.tap{|d| d.force_encoding(text.encoding) if d.encoding != text.encoding }
     end
 
     def fix_url(base_url, url)

--- a/lib/awestruct/front_matter_file.rb
+++ b/lib/awestruct/front_matter_file.rb
@@ -16,6 +16,7 @@ module Awestruct
 
     def load_page
       full_content = File.read( source_path )
+      full_content.force_encoding(@site.encoding) if @site.encoding
       yaml_content = ''
 
       dash_lines = 0
@@ -42,7 +43,7 @@ module Awestruct
 
       begin
         @front_matter = YAML.load( yaml_content ) || {}
-        @front_matter.each do |k,v| 
+        @front_matter.each do |k,v|
           self.send( "#{k}=", v )
         end
       rescue => e

--- a/lib/awestruct/renderable_file.rb
+++ b/lib/awestruct/renderable_file.rb
@@ -20,7 +20,7 @@ module Awestruct
     end
 
     def raw_page_content
-      File.read( self.source_path )
+      File.read( self.source_path ).tap {|f| f.force_encoding(@site.encoding) if @site.encoding }
     end
 
     def render(context)


### PR DESCRIPTION
All text read in from templates/front_matter files will have encoding set to the encoding specified in site.yml.

It's possible to use the magic encoding comment on files that require it, but that won't resolve the Hpricot encoding issue.
