### PR TITLE
fixes: gemspec can be loaded without having awestruct gem installed already

### DIFF
--- a/awestruct.gemspec
+++ b/awestruct.gemspec
@@ -1,4 +1,4 @@
-require 'awestruct/version'
+require File.expand_path("../lib/awestruct/version", __FILE__)
 
 Gem::Specification.new do |s|
     s.platform       =   Gem::Platform::RUBY


### PR DESCRIPTION
Allows bundler to load awestruct gem from git repo.
## Without Change

You end up with behavior like this:

```
caleb@zoidberg $ gem list

*** LOCAL GEMS ***

bundler (1.0.21)
rake (0.8.7)

caleb@zoidberg $ cat Gemfile 
source :rubygems
gem 'awestruct', :git => 'git://github.com/bobmcwhirter/awestruct.git'


caleb@zoidberg $ bundle install
Fetching git://github.com/bobmcwhirter/awestruct.git
remote: Counting objects: 1247, done.
remote: Compressing objects: 100% (495/495), done.
remote: Total 1247 (delta 728), reused 1223 (delta 704)
Receiving objects: 100% (1247/1247), 141.45 KiB | 137 KiB/s, done.
Resolving deltas: 100% (728/728), done.
There was a LoadError while evaluating awestruct.gemspec:
  no such file to load -- awestruct/version from
  /Users/caleb/.rvm/gems/ruby-1.9.2-p290@aws-ng/bundler/gems/awestruct-26e4bbe9eeec/awestruct.gemspec:1:in `<main>'

Does it try to require a relative path? That doesn't work in Ruby 1.9.
```
## With Change

You get expected behavior

```
caleb@zoidberg $ cat Gemfile
source :rubygems
gem 'awestruct', :git => 'git://github.com/simulacre/awestruct.git'

caleb@zoidberg $ bundle install
Fetching git://github.com/simulacre/awestruct.git
remote: Counting objects: 1370, done.
remote: Compressing objects: 100% (590/590), done.
remote: Total 1370 (delta 807), reused 1295 (delta 732)
Receiving objects: 100% (1370/1370), 152.95 KiB | 119 KiB/s, done.
Resolving deltas: 100% (807/807), done.
Fetching source index for http://rubygems.org/
Using rake (0.9.2.2) 
...
```
