### PR TITLE
Fix issue with entities in the content of atom feeds.

### DIFF
--- a/lib/awestruct/extensions/template.atom.haml
+++ b/lib/awestruct/extensions/template.atom.haml
@@ -34,5 +34,5 @@
         %summary
           #{summarize( html_to_text( entry.content ), 100 )}...
         %content{:type=>'html'}
-          = clean_html( escape_once( fully_qualify_urls( site.base_url, find_and_preserve( entry.content ) ) ) )
+          = clean_html( html_escape( fully_qualify_urls( site.base_url, find_and_preserve( entry.content ) ) ) )
   


### PR DESCRIPTION
We had a blog entry with something like `Blah<Foo&Bar>` and in feed readers it was appearing as `Blah` because HAML's `escape_once()` does the following

> Escapes HTML entities in `text`, but without escaping an ampersand
> that is already part of an escaped entity.

In this case we really do want to escape the escaped characters (including ampersand), so `html_escape()` should be the right thing to do, I believe.
