### PR TITLE
Add bootstrap (from Twitter) as framework option

### DIFF
--- a/awestruct.gemspec
+++ b/awestruct.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
     s.add_dependency 'RedCloth', '~> 4.2.5'
     s.add_dependency 'compass', '~> 0.11.5'
     s.add_dependency 'compass-960-plugin', '~> 0.10.4'
+    s.add_dependency 'bootstrap-sass', '~> 2.0.1'
     s.add_dependency 'org-ruby', '~> 0.5.3'
     s.add_dependency 'fssm', '~> 0.2.7'
     s.add_dependency 'json', '~> 1.6.5'

--- a/bin/awestruct
+++ b/bin/awestruct
@@ -34,7 +34,7 @@ def parse(args)
       options.init     = init
       options.generate = false
     end
-    opts.on( '-f', '--framework FRAMEWORK', 'Specify a compass framework during initialization (blueprint, 960)' ) do |framework|
+    opts.on( '-f', '--framework FRAMEWORK', 'Specify a compass framework during initialization (bootstrap, blueprint, 960)' ) do |framework|
       options.framework = framework
     end
     opts.on( '--[no-]scaffold', 'Create scaffolding during initialization (default: true)' ) do |s|

--- a/lib/awestruct/commands/frameworks/bootstrap/base_index.html.haml
+++ b/lib/awestruct/commands/frameworks/bootstrap/base_index.html.haml
@@ -1,0 +1,27 @@
+---
+layout: base
+---
+.hero-unit
+  %h1 You're awestruct!
+  %p Your site is all setup to use Twitter Bootstrap with Awestruct.
+  %p
+    %a.btn.btn-primary.btn-large{ :href=>'http://awestruct.org' }
+      %i.icon-info-sign.icon-white
+      Learn more &raquo;
+.row
+  .span4
+    %h2 About
+    %p Awestruct is a framework for creating static HTML sites. It's inspired by the awesome Jekyll utility in the same genre.
+    %p Additionally, Awestruct integrates technologies such as Compass, Markdown and Haml.
+    %p
+      %a.btn{ :href=>'http://awestruct.org' } View details &raquo; 
+  .span4
+    %h2 Goal
+    %p The goal of Awestruct is to make it trivially easy to bake out non-trivial static websites. In addition to providing template-driven site creation (using Haml), Awestruct provides facilities for easily priming the site creation with additional non-page data.
+    %p
+      %a.btn{ :href=>'http://awestruct.org' } View details &raquo; 
+  .span4
+    %h2 Concept
+    %p The core concept of Awestruct is that of structures, specifically Ruby OpenStruct structures. The struct aspect allows arbitrary, schema-less data to be associated with a specific page or the entire site.
+    %p
+      %a.btn{ :href=>'http://awestruct.org' } View details &raquo; 

--- a/lib/awestruct/commands/frameworks/bootstrap/base_layout.html.haml
+++ b/lib/awestruct/commands/frameworks/bootstrap/base_layout.html.haml
@@ -1,0 +1,29 @@
+!!!5
+%html
+  %head
+    %meta{ :charset=>'utf-8' }
+    %title An awesome site 
+    %meta{ :name=>'viewport', :content=>'width=device-width, initial-scale=1.0' }
+    :css
+      body {
+        padding-top: 60px;
+      }
+    %link{ :rel=>'stylesheet', :type=>'text/css', :href=>'/stylesheets/styles.css' }
+    /[if lt IE 9]
+      %script{ :type=>'text/javascript', :src=>'//html5shim.googlecode.com/svn/trunk/html5.js' }
+  %body
+    .navbar.navbar-fixed-top
+      .navbar-inner
+        .container
+          %a.brand{ :href=>'/' } Project Name
+          %ul.nav
+            %li
+              %a{ :href=>'/' } Home
+    .container
+      ~ content
+      %hr
+      %footer
+        %p &copy; Organization #{Date.today.year}
+    -# Uncomment script tags (remove leading -#) when you're ready to use behaviors
+    -# %script{ :type=>'text/javascript', :src=>'//cdnjs.cloudflare.com/ajax/libs/jquery/1.7.1/jquery.min.js' }
+    -# %script{ :type=>'text/javascript', :src=>'/javascripts/bootstrap-collapse.js' }

--- a/lib/awestruct/commands/init.rb
+++ b/lib/awestruct/commands/init.rb
@@ -25,7 +25,11 @@ module Awestruct
         scaffold_name = ( @framework == 'compass' ? 'blueprint' : @framework )
         if ( @scaffold )
           manifest.copy_file( '_layouts/base.html.haml', File.join( File.dirname(__FILE__), "/frameworks/#{scaffold_name}/base_layout.html.haml" ) )
-          manifest.copy_file( 'index.html.haml', File.join( File.dirname(__FILE__), "/frameworks/base_index.html.haml" ) )
+          if ( File.file? File.join( File.dirname(__FILE__), "/frameworks/#{scaffold_name}/base_index.html.haml" ) )
+            manifest.copy_file( 'index.html.haml', File.join( File.dirname(__FILE__), "/frameworks/#{scaffold_name}/base_index.html.haml" ) )
+          else
+            manifest.copy_file( 'index.html.haml', File.join( File.dirname(__FILE__), "/frameworks/base_index.html.haml" ) )
+          end
           manifest.touch_file( '_config/site.yml' )
         end
         manifest.perform( @dir )

--- a/lib/awestruct/engine.rb
+++ b/lib/awestruct/engine.rb
@@ -2,6 +2,7 @@ require 'ostruct'
 require 'find'
 require 'compass'
 require 'ninesixty'
+require 'bootstrap-sass'
 require 'time'
 
 require 'hashery/opencascade'


### PR DESCRIPTION
Add Twitter Bootstrap as a framework option to the init command. This integration uses the bootstrap-sass gem [1], which is closely tracking the official releases from Twitter.

I also added support for a per-framework index (home) page, in this case to showcase the Twitter Bootstrap framework in the typical way.

[1] http://rubygems.org/gems/bootstrap-sass
