### PR TITLE
return compressed input in minify extension

### DIFF
--- a/lib/awestruct/extensions/minify.rb
+++ b/lib/awestruct/extensions/minify.rb
@@ -28,9 +28,12 @@ module Awestruct
             else
               input
             end
+          else
+            input
           end
+        else
+          input
         end
-        input
       end
 
       private


### PR DESCRIPTION
Fix conditional logic in the minify extension such that the compressed input is returned to the caller.

Previously the minify performed the transformation but then returned the original input.
