### PR TITLE
add ReStructuredText support (via rst2html command)

### DIFF
--- a/lib/awestruct/engine.rb
+++ b/lib/awestruct/engine.rb
@@ -19,6 +19,7 @@ require 'awestruct/sass_file'
 require 'awestruct/scss_file'
 require 'awestruct/orgmode_file'
 require 'awestruct/verbatim_file'
+require 'awestruct/restructuredtext_file'
 
 require 'awestruct/context_helper'
 
@@ -129,6 +130,8 @@ module Awestruct
         page = ScssFile.new( site, path, fixed_relative_path, options )
       elsif ( path =~ /\.org$/ )
         page = OrgmodeFile.new( site, path, fixed_relative_path, options )
+      elsif ( path =~ /\.rst$/ )
+        page = ReStructuredTextFile.new( site, path, fixed_relative_path, options )
       elsif ( File.file?( path ) )
         page = VerbatimFile.new( site, path, fixed_relative_path, options )
       end

--- a/lib/awestruct/restructuredtext_file.rb
+++ b/lib/awestruct/restructuredtext_file.rb
@@ -1,0 +1,23 @@
+require 'open3'
+require 'awestruct/front_matter_file'
+require 'awestruct/restructuredtextable'
+
+module Awestruct
+  class ReStructuredTextFile < FrontMatterFile
+
+    include ReStructuredTextable
+
+    def initialize(site, source_path, relative_source_path, options = {})
+      super(site, source_path, relative_source_path, options)
+    end
+
+    def output_filename
+      File.basename( self.source_path, '.rst' ) + output_extension
+    end
+
+    def output_extension
+      '.html'
+    end
+
+  end
+end

--- a/lib/awestruct/restructuredtextable.rb
+++ b/lib/awestruct/restructuredtextable.rb
@@ -1,0 +1,38 @@
+module Awestruct
+  module ReStructuredTextable
+
+    def render(context)
+      hl = 1
+      if front_matter['initial_header_level'].to_s =~ /^[1-6]$/
+        hl = front_matter['initial_header_level']
+      end
+      rendered = ''
+      begin
+        doc = execute( "rst2html --strip-comments --no-doc-title --initial-header-level=#{hl}", context.interpolate_string( raw_page_content ) )
+        rendered = Hpricot( doc ).at( '/html/body/div[@class="document"]' ).inner_html.strip
+      rescue => e
+        puts e
+        puts e.backtrace
+      end
+      rendered
+    end
+
+    def content
+      context = site.engine.create_context( self )
+      render( context )
+    end
+
+    def execute(command, target)
+      out = ''
+      Open3.popen3(command) do |stdin, stdout, _|
+        stdin.puts target
+        stdin.close
+        out = stdout.read
+      end
+      out.gsub("\r", '')
+    rescue Errno::EPIPE
+      ""
+    end
+
+  end
+end


### PR DESCRIPTION
Add support for ReStructuredText files ending with extension .rst

This is similar to the way ReStructuredText is supported at github. See https://github.com/github/markup/blob/master/lib/github/markup.rb for details.
