### PR TITLE
initial support for asciidoc; room for fine-tuning

### DIFF
--- a/lib/awestruct/asciidoc_file.rb
+++ b/lib/awestruct/asciidoc_file.rb
@@ -1,0 +1,24 @@
+require 'open3'
+require 'pathname'
+require 'awestruct/front_matter_file'
+require 'awestruct/asciidocable'
+
+module Awestruct
+  class AsciiDocFile < FrontMatterFile
+
+    include AsciiDocable
+
+    def initialize(site, source_path, relative_source_path, options = {})
+      super(site, source_path, relative_source_path, options)
+    end
+
+    def output_filename
+      self.source_path.gsub(/\.(asciidoc|adoc)$/, output_extension)
+    end
+
+    def output_extension
+      '.html'
+    end
+
+  end
+end

--- a/lib/awestruct/asciidocable.rb
+++ b/lib/awestruct/asciidocable.rb
@@ -1,0 +1,30 @@
+module Awestruct
+  module AsciiDocable
+
+    def render(context)
+      imagesdir = Pathname.new('/images').relative_path_from(Pathname.new(File.dirname(context.page.relative_source_path)))
+      iconsdir = File.join(imagesdir, 'icons')
+      rendered = ''
+      begin
+        rendered = execute("asciidoc -s -b xhtml11 -a pygments -a icons -a iconsdir='#{iconsdir}' -a imagesdir='#{imagesdir}' -o - -", context.interpolate_string(raw_page_content))
+      rescue => e
+        puts e
+        puts e.backtrace
+      end
+      rendered
+    end
+
+    def execute(command, target)
+      out = ''
+      Open3.popen3(command) do |stdin, stdout, _|
+        stdin.puts target
+        stdin.close
+        out = stdout.read
+      end
+      out.gsub("\r", '')
+    rescue Errno::EPIPE
+      ""
+    end
+
+  end
+end

--- a/lib/awestruct/engine.rb
+++ b/lib/awestruct/engine.rb
@@ -13,6 +13,7 @@ require 'awestruct/haml_file'
 require 'awestruct/erb_file'
 require 'awestruct/textile_file'
 require 'awestruct/markdown_file'
+require 'awestruct/asciidoc_file'
 require 'awestruct/sass_file'
 require 'awestruct/scss_file'
 require 'awestruct/org_mode_file'
@@ -115,6 +116,8 @@ module Awestruct
         page = TextileFile.new( site, path, fixed_relative_path, options )
       elsif ( path =~ /\.md$/ )
         page = MarkdownFile.new( site, path, fixed_relative_path, options )
+      elsif ( path =~ /\.(asciidoc|adoc)$/ )
+        page = AsciiDocFile.new( site, path, fixed_relative_path, options )
       elsif ( path =~ /\.sass$/ )
         page = SassFile.new( site, path, fixed_relative_path, options )
       elsif ( path =~ /\.scss$/ )


### PR DESCRIPTION
Add support for asciidoc files. This requires both asciidoc and pygment to be available on the user's PATH.
