### PR TITLE
rename org_mode* files to orgmode* for consistency

### DIFF
--- a/lib/awestruct/engine.rb
+++ b/lib/awestruct/engine.rb
@@ -120,7 +120,7 @@ module Awestruct
       elsif ( path =~ /\.scss$/ )
         page = ScssFile.new( site, path, fixed_relative_path, options )
       elsif ( path =~ /\.org$/ )
-        page = OrgModeFile.new( site, path, fixed_relative_path, options )
+        page = OrgmodeFile.new( site, path, fixed_relative_path, options )
       elsif ( File.file?( path ) )
         page = VerbatimFile.new( site, path, fixed_relative_path, options )
       end

--- a/lib/awestruct/orgmode_file.rb
+++ b/lib/awestruct/orgmode_file.rb
@@ -1,12 +1,11 @@
-
 require 'sass'
 require 'awestruct/front_matter_file'
 require 'awestruct/orgmodeable'
 
 module Awestruct
-  class OrgModeFile < FrontMatterFile
+  class OrgmodeFile < FrontMatterFile
 
-    include OrgModeable
+    include Orgmodeable
 
     def initialize(site, source_path, relative_source_path, options = {})
       super( site, source_path, relative_source_path, options )

--- a/lib/awestruct/orgmodeable.rb
+++ b/lib/awestruct/orgmodeable.rb
@@ -1,8 +1,7 @@
-
 require 'org-ruby'
 
 module Awestruct
-  module OrgModeable
+  module Orgmodeable
 
     def render(context)
       Orgmode::Parser.new(raw_page_content).to_html


### PR DESCRIPTION
To be consistent with the other markup language files, remove the underscore between "org" and "mode".
