### PR TITLE
not all haml options are symbols, so don't force conversion

### DIFF
--- a/lib/awestruct/hamlable.rb
+++ b/lib/awestruct/hamlable.rb
@@ -4,7 +4,7 @@ module Awestruct
     def render(context)
       rendered = ''
       begin
-        options = (site.haml || {}).inject({}){|h,(k,v)| h[k.to_sym] = v.to_sym; h } 
+        options = (site.haml || {}).inject({}){|h,(k,v)| h[k.to_sym] = v; h } 
         haml_engine = Haml::Engine.new( raw_page_content, options )
         rendered = haml_engine.render( context )
       rescue => e


### PR DESCRIPTION
It's currently impossible to set certain haml options using site.haml since not all of the options that haml accepts are symbols. For instance, if you want to set:

haml:
  attr_wrapper: '"'

This will throw an error that a symbol cannot be converted to a string.

Better is to require the developer to specify a symbol value when needed:

haml:
  format: :html5

This patch implements this policy.
