### PR TITLE
Add textile security & rendering restrictions config

### DIFF
--- a/lib/awestruct/textilable.rb
+++ b/lib/awestruct/textilable.rb
@@ -4,11 +4,14 @@ module Awestruct
     def render(context)
       rendered = ''
       begin
+        # security and rendering restrictions
+        # ex. site.textile = ['no_span_caps']
+        restrictions = (site.textile || []).map { |r| r.to_sym }
         # a module of rule functions is included in RedCloth using RedCloth.send(:include, MyRules)
         # rule functions on that module are activated by setting the property site.textile_rules
         # ex. site.textile_rules = ['emoticons']
         rules = context.site.textile_rules ? context.site.textile_rules.map { |r| r.to_sym } : []
-        rendered = RedCloth.new( context.interpolate_string( raw_page_content ) ).to_html(*rules)
+        rendered = RedCloth.new( context.interpolate_string( raw_page_content ), restrictions ).to_html(*rules)
       rescue => e
         puts e
         puts e.backtrace


### PR DESCRIPTION
Allow textile security & rendering restrictions to be set via site.yml

Example, disable the automatic wrapping of uppercase words in span tags.

textile: [:no_span_caps]

or

textile:
- :no_span_caps

String values also supported.
