### PR TITLE
prettier pagination urls: /page/2 instead of /page2

### DIFF
--- a/lib/awestruct/extensions/paginator.rb
+++ b/lib/awestruct/extensions/paginator.rb
@@ -66,7 +66,7 @@ module Awestruct
           if ( i == 1 )
             page.output_path = File.join( @output_prefix, File.basename( @input_path ) + ".html" )
           else
-            page.output_path = File.join( @output_prefix, "page#{i}.html" )
+            page.output_path = File.join( @output_prefix, "page/#{i}.html" )
           end
           page.paginate_generated = true
           site.pages << page


### PR DESCRIPTION
Most blogs out there follow the convention of /page/2 rather that /page2 for pagination urls (including octopress). It just looks less awkward. I'd like to adopt it.

If it's important to keep the old url style, I'm open to having a configuration option.
