### PR TITLE
Add support for CoffeeScript compilation

### DIFF
--- a/awestruct.gemspec
+++ b/awestruct.gemspec
@@ -26,6 +26,8 @@ spec = Gem::Specification.new do |s|
     s.add_dependency 'hashery', '~> 1.5.0'
     s.add_dependency 'rdiscount', '~> 1.6.8'
     s.add_dependency 'RedCloth', '~> 4.2.9'
+    s.add_dependency 'coffee-script', '~> 2.2.0'
+    s.add_dependency 'nokogiri', '~> 1.5.2'
     s.add_dependency 'compass', '~> 0.12.1'
     s.add_dependency 'compass-960-plugin', '~> 0.10.4'
     s.add_dependency 'bootstrap-sass', '~> 2.0.1'

--- a/lib/awestruct/coffeescript_file.rb
+++ b/lib/awestruct/coffeescript_file.rb
@@ -1,0 +1,23 @@
+require 'awestruct/front_matter_file'
+require 'awestruct/coffeescriptable'
+require 'coffee-script'
+
+module Awestruct
+  class CoffeeScriptFile < FrontMatterFile
+
+    include CoffeeScriptable
+
+    def initialize(site, source_path, relative_source_path, options = {})
+      super(site, source_path, relative_source_path, options)
+    end
+
+    def output_filename
+      File.basename( self.source_path, '.coffee' ) + output_extension
+    end
+
+    def output_extension
+      '.js'
+    end
+
+  end
+end

--- a/lib/awestruct/coffeescriptable.rb
+++ b/lib/awestruct/coffeescriptable.rb
@@ -1,0 +1,14 @@
+module Awestruct
+
+  module CoffeeScriptable
+    def render(context)
+      CoffeeScript.compile context.interpolate_string( raw_page_content ) #, {:no_wrap => true}
+    end
+
+    def content
+      context = site.engine.create_context(self)
+      render(context)
+    end
+  end
+
+end

--- a/lib/awestruct/engine.rb
+++ b/lib/awestruct/engine.rb
@@ -13,6 +13,7 @@ require 'awestruct/site'
 require 'awestruct/haml_file'
 require 'awestruct/erb_file'
 require 'awestruct/textile_file'
+require 'awestruct/coffeescript_file'
 require 'awestruct/markdown_file'
 require 'awestruct/asciidoc_file'
 require 'awestruct/sass_file'
@@ -42,6 +43,7 @@ require 'awestruct/extensions/obfuscate'
 require 'awestruct/extensions/relative'
 require 'awestruct/extensions/assets'
 require 'awestruct/extensions/minify'
+require 'awestruct/extensions/coffeescripttransform'
 
 require 'awestruct/util/inflector'
 require 'awestruct/util/default_inflections'
@@ -120,6 +122,8 @@ module Awestruct
         page = ErbFile.new( site, path, fixed_relative_path, options )
       elsif ( path =~ /\.textile$/ )
         page = TextileFile.new( site, path, fixed_relative_path, options )
+      elsif ( path =~ /\.coffee$/ )
+        page = CoffeeScriptFile.new( site, path, fixed_relative_path, options )
       elsif ( path =~ /\.md$/ )
         page = MarkdownFile.new( site, path, fixed_relative_path, options )
       elsif ( path =~ /\.(asciidoc|adoc)$/ )

--- a/lib/awestruct/extensions/coffeescripttransform.rb
+++ b/lib/awestruct/extensions/coffeescripttransform.rb
@@ -1,0 +1,42 @@
+require 'coffee-script'
+require 'nokogiri'
+
+##
+# Awestruct:Extensions:CoffeeScript is a transformer that compiles inline CoffeeScript in HTML files as JavaScript.
+
+module Awestruct
+  module Extensions
+    class CoffeeScriptTransform
+
+      def transform(site, page, input)
+        ext = File.extname(page.output_path)[1..-1].to_sym
+        case ext
+        when :html
+          encoding = 'UTF-8'
+          encoding = site.encoding unless site.encoding.nil?
+
+          return compile(input, encoding)
+        end
+        return input
+      end
+
+      private
+
+      def compile(input, encoding)
+        html = Nokogiri::HTML(input, nil, encoding);
+        html.search('script').each  do |script|
+          next unless 'text/coffeescript'.eql? script.attr('type')
+
+          if script.attr('src') =~ /\.coffee$/
+            script.set_attribute('src', File.basename( script.attr('src'), '.coffee' ) + '.js')
+          else
+            script.inner_html = CoffeeScript.compile script.inner_html
+          end
+          script.set_attribute('type', 'text/javascript')
+
+        end
+        return html.to_html
+      end
+    end
+  end
+end

--- a/spec/coffeescript_file_spec.rb
+++ b/spec/coffeescript_file_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+require 'awestruct/coffeescript_file'
+require 'awestruct/extensions/coffeescripttransform'
+
+describe Awestruct::CoffeeScriptFile do
+  @@test_script = 'spec/test-coffee-script.coffee'
+
+  it "should compile coffeescript to javascript" do
+    site = OpenStruct.new
+    coffee = Awestruct::CoffeeScriptFile.new(site, File.expand_path(@@test_script), @@test_script)
+    coffee.render(DummyContext.new)
+  end
+
+  class DummyContext
+    def interpolate_string(string)
+      return string
+    end
+  end
+end
+
+describe Awestruct::Extensions::CoffeeScriptTransform do
+  @@test_html = 'spec/test-coffee-script.html'
+
+  it "should compile coffeescript to javascript for inline html" do
+
+    site = OpenStruct.new
+    page = OpenStruct.new
+    page.site = site
+    page.output_path = File.expand_path(@@test_html)
+
+    coffee = Awestruct::Extensions::CoffeeScriptTransform.new
+    transformed = coffee.transform(site, page, File.read(@@test_html))
+
+    html = Nokogiri::HTML(transformed, nil, 'UTF-8');
+
+    verify(html, 'test_head_src', 'text/javascript', 'test.js')
+    verify(html, 'test_head', 'text/javascript', nil)
+    verify(html, 'test_inline_javascript', 'text/javascript', nil)
+    verify(html, 'test_inline_coffeescript', 'text/javascript', nil)
+
+  end
+
+  private
+
+  def verify(html, id, expected_type, expected_src)
+    script = html.xpath("//script[@id='#{id}']")
+    script.attr('type').to_s.should == expected_type
+    if !expected_src.nil?
+      script.attr('src').to_s.should == expected_src
+    end
+  end
+end

--- a/spec/test-coffee-script.coffee
+++ b/spec/test-coffee-script.coffee
@@ -1,0 +1,1 @@
+countdown = (num for num in [10..1])

--- a/spec/test-coffee-script.html
+++ b/spec/test-coffee-script.html
@@ -1,0 +1,21 @@
+<html>
+<head>
+	<script id="test_head_src" type="text/coffeescript" src="test.coffee" />
+
+	<script id="test_head" type="text/coffeescript">
+		countdown = (num for num in [10..1])
+	</script>
+
+</head>
+
+<body>
+
+	<script id="test_inline_javascript" type="text/javascript">
+		alert('a')
+	</script>
+
+	<script id="test_inline_coffeescript" type="text/coffeescript">
+		countdown = (num for num in [10..1])
+	</script>
+</body>
+</html>


### PR DESCRIPTION
Compile files of type x.coffee to javascript x.js

Adding CoffeeScriptTransformer to the pipeline will give you  inline html script tag coffeescript compilation.
The transformer will scan html files for script[type='text/coffeescript'] and compile the inner_html or rename the src if the script is refering to a .coffee file

transformer Awestruct::Extensions::CoffeeScriptTransform.new
