### PR TITLE
Fixes removing directory issues when using --force

### DIFF
--- a/bin/awestruct
+++ b/bin/awestruct
@@ -162,7 +162,7 @@ end
 
 if ( options.force )
   if File.exist?( site_path )
-    FileUtils.rmdir( site_path )
+    FileUtils.rm_rf( site_path )
   end
 end
 


### PR DESCRIPTION
Fixes issues like this:

<pre>
/usr/lib/ruby/1.8/fileutils.rb:264:in `rmdir': Directory not empty - /home/goldmann/git/goldmann.pl/_site (Errno::ENOTEMPTY)
    from /usr/lib/ruby/1.8/fileutils.rb:264:in `rmdir'
    from /usr/lib/ruby/1.8/fileutils.rb:263:in `each'
    from /usr/lib/ruby/1.8/fileutils.rb:263:in `rmdir'
    from /home/goldmann/.gem/ruby/1.8/gems/awestruct-0.2.18/bin/awestruct:165
    from /usr/bin/awestruct:19:in `load'
    from /usr/bin/awestruct:19
</pre>
