### PR TITLE
Fix for corrupt binary files in windows

### DIFF
--- a/lib/awestruct/engine.rb
+++ b/lib/awestruct/engine.rb
@@ -248,7 +248,7 @@ module Awestruct
       $stderr.puts "rendering #{page.source_path} -> #{page.output_path}"
       rendered = render_page(page, true)
       FileUtils.mkdir_p( File.dirname( generated_path ) )
-      File.open( generated_path, 'w' ) do |file|
+      File.open( generated_path, 'wb' ) do |file|
         file << rendered
       end
     end

--- a/lib/awestruct/verbatim_file.rb
+++ b/lib/awestruct/verbatim_file.rb
@@ -7,6 +7,11 @@ module Awestruct
     def initialize(site, source_path, relative_source_path, options = {})
       super( site, source_path, relative_source_path, options )
     end
-
+    
+    def raw_page_content
+      IO.open(IO.sysopen(self.source_path, "rb"), "rb" ).read
+    end
+    
   end
+  
 end


### PR DESCRIPTION
The issue here appears to be that files if not opened and written with the binary option are corrupted.

This is for https://github.com/awestruct/awestruct/issues/69
