### PR TITLE
Added an 'exclude' option to the rsync deployer

### DIFF
--- a/lib/awestruct/deploy/rsync_deploy.rb
+++ b/lib/awestruct/deploy/rsync_deploy.rb
@@ -10,10 +10,15 @@ module Awestruct
         @site_path = File.join( site_config.output_dir, '/' ).gsub(/^\w:\//, '/')
         @host      = deploy_config['host']
         @path      = File.join( deploy_config['path'], '/' )
+        @exclude   = deploy_config['exclude']
       end
 
       def run
-        cmd = "rsync -r -l -i --no-p --no-g --chmod=Dg+sx,ug+rw --delete #{@site_path} #{@host}:#{@path}"
+        exclude_option = ""
+        if ! (@exclude.nil? or @exclude.empty?)
+          exclude_option = "--exclude=#{@exclude}"
+        end
+        cmd = "rsync -r -l -i --no-p --no-g --chmod=Dg+sx,ug+rw --delete #{exclude_option} #{@site_path} #{@host}:#{@path}"
         Open3.popen3( cmd ) do |stdin, stdout, stderr|
           stdin.close
           threads = []


### PR DESCRIPTION
if you add an exclude option to the site yaml config, that exclude will be passed through to the rsync call.

Example:

```
  production:
    base_url: http://www.bleathem.ca/
    deploy:
      host: bleathem.ca
      path: /home/bleathem/bleathem.ca/
      exclude: talks
```

Since it's passed through, the syntax for the exclude option follows the rsync syntax.
