### PR TITLE
add output_filename method to page to fix sitemap extension

### DIFF
--- a/lib/awestruct/page.rb
+++ b/lib/awestruct/page.rb
@@ -76,6 +76,9 @@ module Awestruct
       handler.output_extension
     end
 
+    def output_filename
+      handler.output_filename
+    end
 
     def source_path
       handler.path.to_s


### PR DESCRIPTION
Currently the sitemap extension will add robots.txt to the sitemap even though it is defined in the exclude list. This is because there is out output_filename on page and thus it always resolves to nil and passes through the check code.
