### PR TITLE
fix popen3 hang bug

### DIFF
--- a/lib/awestruct/handlers/base_handler.rb
+++ b/lib/awestruct/handlers/base_handler.rb
@@ -99,6 +99,7 @@ module Awestruct
       def execute_shell(command, input=nil)
         Open3.popen3(command) do |stdin, stdout, _|
           stdin.puts input unless input.nil?
+          stdin.close
           out = stdout.read
         end
       rescue Errno::EPIPE


### PR DESCRIPTION
the pipe requires stdin's EOF to yield output, so
better close it before asking for output

(and we're not streaming, just sending already
allocated data)
