### PR TITLE
Add support for GitHub Pages deploy target Repository

### DIFF
--- a/lib/awestruct/deploy/github_pages_deploy.rb
+++ b/lib/awestruct/deploy/github_pages_deploy.rb
@@ -8,6 +8,7 @@ module Awestruct
       def initialize( site_config, deploy_config )
         @site_path = site_config.output_dir
         @branch    = deploy_config[ 'branch' ] || 'gh-pages'
+        @repo      = deploy_config[ 'repository' ] || 'origin'
       end
 
       def run
@@ -23,7 +24,7 @@ module Awestruct
         current_branch = git.current_branch
         git.branch( @branch ).checkout
         add_and_commit_site @site_path
-        git.push( 'origin', @branch )
+        git.push( @repo, @branch )
         git.checkout( current_branch )
       end
 

--- a/spec/github_pages_deploy_spec.rb
+++ b/spec/github_pages_deploy_spec.rb
@@ -9,6 +9,7 @@ describe Awestruct::Deploy::GitHubPagesDeploy do
 
     deploy_config = mock
     deploy_config.stub(:[]).with('branch').and_return('the-branch')
+    deploy_config.stub(:[]).with('repository').and_return('the-repo')
     @deployer = Awestruct::Deploy::GitHubPagesDeploy.new( site_config, deploy_config )
 
     @git = mock
@@ -35,7 +36,7 @@ describe Awestruct::Deploy::GitHubPagesDeploy do
   it "should save and restore the current branch when publishing" do
     @git.should_receive(:current_branch).and_return( 'bacon' )
     @git.stub_chain(:branch, :checkout)
-    @git.should_receive(:push).with('origin', 'the-branch')
+    @git.should_receive(:push).with('the-repo', 'the-branch')
     @git.should_receive(:checkout).with( 'bacon' )
 
     @deployer.stub(:add_and_commit_site)


### PR DESCRIPTION
Property: repository (default: origin)

```
The "remote" repository that is the destination of the push operation.
This parameter can be either a URL or the name of a remote.
(ref: git help push)
```

Example:

```
deploy:
  host: github_pages
  branch: master
  repository: upstream
```
