### PR TITLE
Add a redirect handler

### DIFF
--- a/lib/awestruct/handler_chains.rb
+++ b/lib/awestruct/handler_chains.rb
@@ -11,6 +11,7 @@ require 'awestruct/handlers/sass_handler'
 require 'awestruct/handlers/scss_handler'
 require 'awestruct/handlers/javascript_handler'
 require 'awestruct/handlers/coffeescript_handler'
+require 'awestruct/handlers/redirect_handler'
 
 module Awestruct
 
@@ -28,6 +29,7 @@ module Awestruct
       Awestruct::Handlers::ScssHandler::CHAIN,
       Awestruct::Handlers::JavascriptHandler::CHAIN,
       Awestruct::Handlers::CoffeescriptHandler::CHAIN,
+      Awestruct::Handlers::RedirectHandler::CHAIN,
       HandlerChain.new( /.*/, Awestruct::Handlers::FileHandler )
     ]
 

--- a/lib/awestruct/handlers/redirect_handler.rb
+++ b/lib/awestruct/handlers/redirect_handler.rb
@@ -1,0 +1,48 @@
+require 'awestruct/handler_chain'
+require 'awestruct/handlers/base_handler'
+require 'awestruct/handlers/file_handler'
+require 'awestruct/handlers/front_matter_handler'
+require 'awestruct/handlers/interpolation_handler'
+
+module Awestruct
+  module Handlers
+    class RedirectHandler < BaseHandler
+
+
+      CHAIN = Awestruct::HandlerChain.new( /\.redirect$/,
+        Awestruct::Handlers::FileHandler,
+        Awestruct::Handlers::FrontMatterHandler,
+        Awestruct::Handlers::InterpolationHandler,
+        Awestruct::Handlers::RedirectHandler
+      )
+
+      def initialize(site, delegate)
+        super( site, delegate )
+      end
+
+      def simple_name
+        File.basename( relative_source_path, '.redirect' ) 
+      end
+
+      def output_filename
+        simple_name + output_extension
+      end
+
+      def output_extension
+        '.html'
+      end
+
+      def content_syntax
+        :text
+      end
+
+      def rendered_content(context, with_layouts=false)
+        url = delegate.rendered_content( context, with_layouts ).strip
+        %{<head><meta http-equiv="location" content="URL=#{url}" /></head>}
+      end
+
+    end
+  end
+end
+
+

--- a/spec/redirect_handler_spec.rb
+++ b/spec/redirect_handler_spec.rb
@@ -1,0 +1,38 @@
+require 'hashery/open_cascade'
+require 'awestruct/page'
+require 'awestruct/handlers/file_handler'
+require 'awestruct/handlers/redirect_handler'
+
+require 'hashery/open_cascade'
+
+describe Awestruct::Handlers::RedirectHandler do
+
+  before :all do
+    @page = Awestruct::Page.new( site, Awestruct::Handlers::RedirectHandler::CHAIN.create( site, handler_file("simple-redirect-page.redirect") ) )
+    @page.prepare!
+    @interpolated = Awestruct::Page.new( site, Awestruct::Handlers::RedirectHandler::CHAIN.create( site, handler_file("redirect-page.redirect") ) )
+    @interpolated.prepare!
+  end
+
+  def site
+    @site ||= OpenCascade.new( :encoding=>false, 
+                               :dir=>Pathname.new( File.dirname(__FILE__) + '/test-data/handlers' ), 
+                               :crunchy => "bacon", 
+                               :config => { :dir => 'foo' } )
+  end
+
+  def handler_file(path)
+    Pathname.new( File.dirname( __FILE__ ) + "/test-data/handlers/#{path}" )
+  end
+
+  it "should emit <meta http-equiv ...>" do
+    @page.content.should =~ %r(<head><meta http-equiv="location" content="URL=http://google.com" /></head>)
+  end
+
+  it "should interpolate variables" do
+    @interpolated.content.should =~ %r(<head><meta http-equiv="location" content="URL=http://bacon.com" /></head>)
+  end
+
+end
+
+

--- a/spec/test-data/handlers/redirect-page.redirect
+++ b/spec/test-data/handlers/redirect-page.redirect
@@ -1,0 +1,1 @@
+http://#{site.crunchy}.com

--- a/spec/test-data/handlers/simple-redirect-page.redirect
+++ b/spec/test-data/handlers/simple-redirect-page.redirect
@@ -1,0 +1,1 @@
+http://google.com


### PR DESCRIPTION
With this handler, you can now have a file /somedir/somefile.redirect
which should contain only a URL. RedirectHandler will use this to create
a file /somedir/somefile.html which has nothing but a <head> section
with a <meta http-equiv..> redirect to the URL contained in the original
file. You may also use variable interpolation, so that the .redirect
file can contain something like http://#{site.redirhost}/. See the spec
redir_handler_spec.rb for an example.
