### PR TITLE
Use output_path rather than output_filename as it is more specific on Sitemap Exlcudes

### DIFF
--- a/lib/awestruct/extensions/sitemap.rb
+++ b/lib/awestruct/extensions/sitemap.rb
@@ -9,7 +9,7 @@ module Awestruct
     class Sitemap
 
       def initialize
-        @excluded_files = [ '.htaccess', 'robots.txt' ].to_set
+        @excluded_files = [ '/.htaccess', '/robots.txt' ].to_set
         @excluded_extensions = ['.atom', '.scss', '.css', '.png', '.jpg', '.gif', '.js' ].to_set
       end
 


### PR DESCRIPTION
Files like tagger don't have an output_filename but do have an output_path also it makes sense to define the full path as you may want to exclude /blog/index.html but not /news/index.html
