### PR TITLE
Add site.posts_archive for Issue #80

### DIFF
--- a/lib/awestruct/extensions/posts.rb
+++ b/lib/awestruct/extensions/posts.rb
@@ -8,7 +8,8 @@ module Awestruct
       end
 
       def execute(site)
-        posts = []
+        posts   = []
+        archive = Archive.new
 
         site.pages.each do |page|
           year, month, day, slug = nil
@@ -36,14 +37,8 @@ module Awestruct
             # if a date was found create a post
             if( year and month and day)
               page.slug ||= slug
-              #context = OpenStruct.new({
-                #:site=>site,
-                #:page=>page,
-              #})
               context = page.create_context
-              #page.body = page.render( context )
               page.output_path = "#{@path_prefix}/#{year}/#{month}/#{day}/#{page.slug}.html"
-              #page.layout = 'post'
               posts << page
             end
           end
@@ -59,12 +54,30 @@ module Awestruct
              last.send( "previous_#{singular}=", e )
           end
           last = e
+          archive << e
         end
 
         site.send( "#{@assign_to}=", posts )
+        site.send( "#{assign_to}_archive = ", archive )
 
+      end
+
+
+      class Archive
+        attr_accessor :posts
+
+        def initialize()
+          @posts  = {}
+        end
+
+        def <<( post )
+          posts[post.date.year] ||= {}
+          posts[post.date.year][post.date.month] ||= []
+          posts[post.date.year][post.date.month] << post
+        end
       end
 
     end
   end
 end
+

--- a/spec/posts_archive_spec.rb
+++ b/spec/posts_archive_spec.rb
@@ -1,0 +1,22 @@
+require 'awestruct/extensions/posts'
+
+describe Awestruct::Extensions::Posts::Archive do
+
+  it "should store pages by year and month" do
+    archive = Awestruct::Extensions::Posts::Archive.new
+    page = create_page( 2012, 8 )
+    archive << page
+    archive.posts[2012].should_not be_nil
+    archive.posts[2012][8][0].should == page
+  end
+
+  def create_page(year, month)
+    page = mock
+    page.stub_chain(:date, :year).and_return( year )
+    page.stub_chain(:date, :month).and_return( month )
+    page
+  end
+
+end
+
+


### PR DESCRIPTION
Now, in addition to `site.posts` the Posts extension provides a
`site.posts_archive` method returning Archive::Extensions::Posts:Archive
To get an array of all the posts for August of 2012, call
`site.posts_archive.posts[2012][08]` which returns an array of posts
sorted by date.
