### PR TITLE
Fix incorrect boolean false return

### DIFF
--- a/lib/awestruct/astruct_mixin.rb
+++ b/lib/awestruct/astruct_mixin.rb
@@ -22,8 +22,8 @@ module Awestruct
     end
 
     def [](key)
-      r = super( key ) || super( key.to_sym ) || super( key.to_s  )
-      transform_entry( key, r )
+      r = [key, key.to_sym, key.to_s].find { |fk| !super(fk).nil? }
+      transform_entry( key, super(r) )
     end
 
     def method_missing(sym, *args, &blk)
@@ -73,7 +73,7 @@ module Awestruct
     end
 
     def inspect
-      "AStruct{...}"
+      "AStruct<#{super.to_s}>"
     end
 
   end


### PR DESCRIPTION
Fix subtle bug that causes Ruby 1.9.x to return stored 'false' boolean values as nil due to || evaluation

Ruby 1.9

```
[2] pry(main)> require 'astruct'
=> true
[3] pry(main)> as2 = Awestruct::AStruct.new
=> {}
[4] pry(main)> as2.pae=false
=> false
[5] pry(main)> as2.pae
=> nil       <--------- nil
[6] pry(main)> as2.pae_test=true
=> true
[7] pry(main)> as2.pae_test
=> true
```

After fix

```
[4] pry(main)> as = BoxGrinder::AStruct.new(:awestruct => false)
=> {:awestruct=>false}
[5] pry(main)> as.awestruct
=> false
```
