### PR TITLE
Add support for Atom categories

### DIFF
--- a/lib/awestruct/extensions/template.atom.haml
+++ b/lib/awestruct/extensions/template.atom.haml
@@ -32,6 +32,9 @@
                 %email= entry.author.email
             - else
               %name= entry.author
+        - if ( not entry.tags.nil? )
+          - for tag in entry.tags
+            %category{:term=>"#{tag}"}
         %summary
           #{summarize( html_to_text( entry.content ), 100 )}
         %content{:type=>'html'}


### PR DESCRIPTION
category to map tags is as good as any solution
and complies with the atom validators
http://edward.oconnor.cx/2007/02/representing-tags-in-atom
