### PR TITLE
Use proper variable name in transformers loop

### DIFF
--- a/lib/awestruct/engine.rb
+++ b/lib/awestruct/engine.rb
@@ -174,8 +174,8 @@ module Awestruct
         p.helpers.each do |h|
           pipeline.helper( h )
         end
-        p.transformers.each do |e|
-          pipeline.transformer( e )
+        p.transformers.each do |t|
+          pipeline.transformer( t )
         end
       end
     end


### PR DESCRIPTION
Use the variable name t instead of e when looping over transformers.
