### PR TITLE
Move :html, :js and :css compression from using cmd to ruby gems

### DIFF
--- a/awestruct.gemspec
+++ b/awestruct.gemspec
@@ -35,6 +35,8 @@ spec = Gem::Specification.new do |s|
     s.add_dependency 'rest-client', '~> 1.6.7'
 #    s.add_dependency 'notifier', '~> 0.1.4'
     s.add_dependency 'git', '~> 1.2.5'
+    s.add_dependency 'htmlcompressor', '~> 0.0.3'
+    s.add_dependency 'yui-compressor', '~> 0.9.4'
 
     s.add_dependency 'listen', '~> 0.5.0'
     s.add_dependency 'thin', '~> 1.4.1'

--- a/spec/minify_spec.rb
+++ b/spec/minify_spec.rb
@@ -2,17 +2,59 @@ require 'spec_helper'
 require 'awestruct/extensions/minify'
 
 describe Awestruct::Extensions::Minify do
-  before :all do
-    @minifier = Awestruct::Extensions::Minify.new
-  end
 
   it "should ignore files with no extension" do
     site = mock
-    site.should_receive(:minify).and_return true
     page = mock
+
+    site.should_receive(:minify).and_return true
     page.should_receive(:output_path).and_return "CNAME"
     input = "some input"
-    @minifier.transform(site, page, input).should == input
+
+    minifier = Awestruct::Extensions::Minify.new
+    minifier.transform(site, page, input).should == input
   end
 
+  it "should compress html files" do
+    site = mock
+    page = mock
+
+    site.should_receive(:minify).and_return true
+    site.should_receive(:minify_html_opts).and_return( {:remove_comments => false} )
+    page.should_receive(:output_path).any_number_of_times.and_return "test.html"
+
+    input = "<html><a   href='' />  \n</html><!--test-->"
+    expected_output = "<html><a href=''/> </html><!--test-->"
+
+    minifier = Awestruct::Extensions::Minify.new [:html]
+    minifier.transform(site, page, input).should == expected_output
+  end
+
+  it "should compress css files" do
+    site = mock
+    page = mock
+
+    site.should_receive(:minify).and_return true
+    page.should_receive(:output_path).any_number_of_times.and_return "test.css"
+
+    input = ".class     { \n a: b   ;}"
+    expected_output = ".class{a:b}"
+
+    minifier = Awestruct::Extensions::Minify.new [:css]
+    minifier.transform(site, page, input).should == expected_output
+  end
+
+  it "should compress js files" do
+    site = mock
+    page = mock
+
+    site.should_receive(:minify).and_return true
+    page.should_receive(:output_path).any_number_of_times.and_return "test.js"
+
+    input = "function    a (a,     c) { \n a = \"a\";\n }"
+    expected_output = "function a(a,c){a=\"a\"};"
+
+    minifier = Awestruct::Extensions::Minify.new [:js]
+    minifier.transform(site, page, input).should == expected_output
+  end
 end


### PR DESCRIPTION
The minfiy extension rely on calling yuicompressor and htmlcompressor on
the command line with no control if they are installed or not. Change Minify
to use the htmlcompressor and yui-compressor ruby gems to control the
dependencies.

pngcrush is untouched and still rely on calling the cmd.

Includes :html, :css and :js compression spec tests.
