### PR TITLE
Use RbConfig instead of deprecated Config

### DIFF
--- a/lib/awestruct/handlers/interpolation_handler.rb
+++ b/lib/awestruct/handlers/interpolation_handler.rb
@@ -32,7 +32,7 @@ module Awestruct
       end
 
       def ruby_19?
-        @is_ruby_19 ||= (::Config::CONFIG['ruby_version'] =~ %r(^1\.9))
+        @is_ruby_19 ||= (::RbConfig::CONFIG['ruby_version'] =~ %r(^1\.9))
       end
 
     end

--- a/spec/interpolation_handler_spec.rb
+++ b/spec/interpolation_handler_spec.rb
@@ -17,7 +17,7 @@ describe Awestruct::Handlers::InterpolationHandler do
   end
 
   it "should correctly interpolate complicated stuff that includes regular expressions [Issue #139]" do
-    if ::Config::CONFIG['ruby_version'] =~ %r(^1\.9)
+    if ::RbConfig::CONFIG['ruby_version'] =~ %r(^1\.9)
       input = 'url = url.replace(/\/?#$/, \'\');' 
       handler = build_handler( input )
       content = handler.rendered_content( OpenCascade.new )


### PR DESCRIPTION
This fixes the following warning in Ruby 1.8.x and Ruby 1.9.3

```
Use RbConfig instead of obsolete and deprecated Config.
```

RbConfig is also available in 1.8.7, so this change does not raise any compatibility issue (assuming that is our minimum version).
