### PR TITLE
Skip page if draft front-matter attribute is true

### DIFF
--- a/lib/awestruct/page_loader.rb
+++ b/lib/awestruct/page_loader.rb
@@ -46,7 +46,7 @@ module Awestruct
         unless path.directory?
           puts "loading #{relative_path}" if (site.config.verbose)
           page = load_page( path, prepare )
-          if ( page )
+          if ( page && !page.draft )
             #puts "loaded! #{path} and added to site"
             #inherit_front_matter( page )
             site.send( @target ) << page

--- a/spec/page_loader_spec.rb
+++ b/spec/page_loader_spec.rb
@@ -27,7 +27,7 @@ describe Awestruct::PageLoader do
     page.relative_source_path.should be_nil
   end
 
-  it "should be able to load all site pages" do
+  it "should be able to load all non-draft site pages" do
     @loader.load_all
     @site.pages.size.should == 2
 

--- a/spec/test-data/page-loader/page-draft.md
+++ b/spec/test-data/page-loader/page-draft.md
@@ -1,0 +1,5 @@
+---
+draft: true
+---
+
+This page is a draft. It should not be published.


### PR DESCRIPTION
Enable a way to mark a page as a draft by setting a front-matter attribute with the same name to true. This allows pages to be held back from publishing.
