### PR TITLE
Set site.path to context path, prepend to page urls

### DIFF
--- a/lib/awestruct/context_helper.rb
+++ b/lib/awestruct/context_helper.rb
@@ -1,4 +1,5 @@
 require 'hpricot'
+require 'uri'
 
 module Awestruct
   module ContextHelper
@@ -37,17 +38,17 @@ module Awestruct
       close_tags(text.split(/ /)[0, numwords].join(' ') + ellipsis)
     end
 
-    def fully_qualify_urls(base_url, text)
+    def fully_qualify_urls(base_url, text, context_path = nil)
       doc = Hpricot( text )
 
       doc.search( "//a" ).each do |a|
-        a['href'] = fix_url( base_url, a['href'] ) if a['href']
+        a['href'] = fix_url( base_url, a['href'], context_path ) if a['href']
       end
       doc.search( "//link" ).each do |link|
-        link['href'] = fix_url( base_url, link['href'] )
+        link['href'] = fix_url( base_url, link['href'], context_path )
       end
       doc.search( "//img" ).each do |img|
-        img['src'] = fix_url( base_url, img['src'] )
+        img['src'] = fix_url( base_url, img['src'], context_path )
       end
       # Hpricot::Doc#to_s output encoding is not necessarily the same as the encoding of text
       if RUBY_VERSION.start_with? '1.8'
@@ -59,9 +60,15 @@ module Awestruct
       end
     end
 
-    def fix_url(base_url, url)
+    # prepend the base_url to absolute urls
+    # if a context_path is specified, strip it before prepending the base_url
+    def fix_url(base_url, url, context_path = nil)
       return url unless ( url =~ /^\// )
-      "#{base_url}#{url}"
+      if (context_path && context_path.size > 0 && url.slice(0..context_path.size-1) == context_path)
+        "#{base_url}#{url.slice(context_path.size..-1)}"
+      else
+        "#{base_url}#{url}"
+      end
     end
   end
 

--- a/lib/awestruct/engine.rb
+++ b/lib/awestruct/engine.rb
@@ -75,6 +75,7 @@ module Awestruct
 
     def set_base_url(base_url, default_base_url)
       site.path = ''
+      site.root_url = ''
       if ( base_url )
         site.base_url = base_url
       end
@@ -87,7 +88,9 @@ module Awestruct
         if ( site.base_url =~ /^(.*)\/$/ )
           site.base_url = $1
         end
-        site.path = URI(site.base_url).path
+        base_uri = URI(site.base_uri)
+        site.root_url = base_uri.scheme + '://' + base_uri.host
+        site.path = base_uri.path
       end
 
     end

--- a/lib/awestruct/extensions/template.atom.haml
+++ b/lib/awestruct/extensions/template.atom.haml
@@ -15,15 +15,15 @@
         %name= site.author
   - unless page.entries.empty?
     %updated= page.entries.first.input_mtime.xmlschema
-    %link{:rel=>"self",      :type=>"application/atom+xml", :href=>"#{site.base_url}#{page.url}" }
+    %link{:rel=>"self",      :type=>"application/atom+xml", :href=>"#{site.root_url}#{page.url}" }
     %link{:rel=>"alternate", :type=>"text/html",            :href=>"#{page.content_url}/" }
     - for entry in page.entries
       %entry
-        %id #{site.base_url}#{entry.url}
+        %id #{site.root_url}#{entry.url}
         %title= escape_once( entry.title )
         %updated= entry.input_mtime.xmlschema
         %published= entry.date.xmlschema
-        %link{:rel=>"alternate", :type=>"text/html", :href=>"#{site.base_url}#{entry.url}" }
+        %link{:rel=>"alternate", :type=>"text/html", :href=>"#{site.root_url}#{entry.url}" }
         - if ( not entry.author.nil? )
           %author
             - if ( defined?( entry.author.name ) )
@@ -38,5 +38,5 @@
         %summary
           #{summarize( html_to_text( entry.content ), 100 )}
         %content{:type=>'html'}
-          = clean_html( html_escape( fully_qualify_urls( site.base_url, find_and_preserve( entry.content ) ) ) )
+          = clean_html( html_escape( fully_qualify_urls( site.base_url, find_and_preserve( entry.content ), site.path ) ) )
   


### PR DESCRIPTION
Calculate the context path (as we know it in the Java world) from the site.base_url and prepend it to the page urls. This allows an Awestruct site to work when running under a sub-path of the domain.

The page urls don't need the full base url since they are already served from that domain. The context path just ensures that the relative references (from one page to another) are correct.
