### PR TITLE
Handle case when using detached branch (as Travis CI does)

### DIFF
--- a/lib/awestruct/deploy/github_pages_deploy.rb
+++ b/lib/awestruct/deploy/github_pages_deploy.rb
@@ -11,6 +11,11 @@ module Awestruct
 
       def publish_site
         current_branch = git.current_branch
+        # we may be on a detached branch,
+        # in which case use that commit as the branch
+        if current_branch == '(no branch)'
+          current_branch = git.revparse('HEAD')
+        end
         git.branch( @branch ).checkout
         add_and_commit_site @site_path
         git.push( @repo, @branch )

--- a/spec/github_pages_deploy_spec.rb
+++ b/spec/github_pages_deploy_spec.rb
@@ -42,4 +42,15 @@ describe Awestruct::Deploy::GitHubPagesDeploy do
     @deployer.stub(:add_and_commit_site)
     @deployer.run(@deploy_config)
   end
+
+  it "should save and restore the current detached branch when publishing" do
+    @git.should_receive(:current_branch).and_return( '(no branch)' )
+    @git.should_receive(:revparse).with( 'HEAD' ).and_return( '0123456789' )
+    @git.stub_chain(:branch, :checkout)
+    @git.should_receive(:push).with('the-repo', 'the-branch')
+    @git.should_receive(:checkout).with( '0123456789' )
+
+    @deployer.stub(:add_and_commit_site)
+    @deployer.run(@deploy_config)
+  end
 end


### PR DESCRIPTION
If the current branch is detached, handle it gracefully. An attempt to checkout the branch '(no branch)' will fail. In this case, the current commit sha (retrieved from revparse HEAD) must be used as the return branch.

This problem is observed when Travis CI uses this deployer.
