### PR TITLE
Use Asciidoctor to render AsciiDoc by default

### DIFF
--- a/awestruct.gemspec
+++ b/awestruct.gemspec
@@ -20,6 +20,7 @@ spec = Gem::Specification.new do |s|
     s.has_rdoc       =   true
 
     s.add_dependency 'hpricot', '~> 0.8.6'
+    s.add_dependency 'asciidoctor', '>= 0.0.7'
     s.add_dependency 'haml', '~> 3.1.4'
     s.add_dependency 'sass', '~> 3.1.15'
     s.add_dependency 'less', '~> 2.2.2'

--- a/lib/awestruct/handlers/base_handler.rb
+++ b/lib/awestruct/handlers/base_handler.rb
@@ -97,8 +97,8 @@ module Awestruct
         chain.flatten
       end
 
-      def execute_shell(command, input=nil)
-        Open3.popen3(Shellwords.escape( command )) do |stdin, stdout, _|
+      def execute_shell(command, input=nil, escape=true)
+        Open3.popen3(escape ? Shellwords.escape( command ) : command) do |stdin, stdout, _|
           stdin.puts input unless input.nil?
           stdin.close
           out = stdout.read

--- a/spec/asciidoc_handler_spec.rb
+++ b/spec/asciidoc_handler_spec.rb
@@ -30,14 +30,40 @@ describe Awestruct::Handlers::AsciidocHandler do
     asciidoc_handler.simple_name.should == 'asciidoc-page' 
   end
   
-=begin
-  it "should successfully render an ASCIIDoc page" do
+  it "should render an AsciiDoc page using Asciidoctor by default" do
     file_handler = Awestruct::Handlers::FileHandler.new( @site, handler_file( "asciidoc-page.adoc" ) )
     asciidoc_handler = Awestruct::Handlers::AsciidocHandler.new( @site, file_handler )
 
+    @site.asciidoc[:engine].should == 'asciidoctor'
+    @site.asciidoc[:engine_loaded].should == true
     rendered = asciidoc_handler.rendered_content( create_context )
     rendered.should_not be_nil
-    rendered.should =~ %r(<h1>This is a Markdown page</h1>) 
+    rendered.gsub(/(^\s*\n|^\s*)/, '').should =~ %r(<div id='preamble'>
+<div class='sectionbody'>
+<div class='paragraph'>
+<p>This is <strong>AsciiDoc</strong> in Awestruct.</p>
+</div>
+</div>
+</div>) 
+  end
+
+=begin
+  # TODO to run this test in CI requires setting up asciidoc
+  it "should render an AsciiDoc page using system asciidoc command when engine is system" do
+    @site.asciidoc[:engine] = 'system'
+    file_handler = Awestruct::Handlers::FileHandler.new( @site, handler_file( "asciidoc-page.adoc" ) )
+    asciidoc_handler = Awestruct::Handlers::AsciidocHandler.new( @site, file_handler )
+
+    @site.asciidoc[:engine].should == 'system'
+    @site.asciidoc[:engine_loaded].should == true
+    rendered = asciidoc_handler.rendered_content( create_context )
+    puts rendered
+    rendered.should_not be_nil
+    rendered.should =~ %r(<div id="preamble">
+<div class="sectionbody">
+<div class="paragraph"><p>This is <strong>AsciiDoc</strong> in Awestruct.</p></div>
+</div>
+</div>) 
   end
 =end
 

--- a/spec/test-data/handlers/asciidoc-page.adoc
+++ b/spec/test-data/handlers/asciidoc-page.adoc
@@ -1,1 +1,3 @@
-This is _asciidoc_
+= Title
+
+This is *AsciiDoc* in Awestruct.


### PR DESCRIPTION
- allow the site config asciidoc.engine to control which engine is used
- set default engine to asciidoctor
- load required library lazily
- add test to ensure asciidoctor is loaded properly
- fix the call to the asciidoc system command (but leave test disabled)
