### PR TITLE
Removing use of #{site.base_url} in the paginator

### DIFF
--- a/lib/awestruct/extensions/paginator.rb
+++ b/lib/awestruct/extensions/paginator.rb
@@ -13,7 +13,7 @@ module Awestruct
         def links
           html = %Q(<div class="pagination-links">)
           unless ( previous_page.nil? )
-            html += %Q(<a href="#{site.base_url}#{previous_page.url}" class="previous-link">Previous</a> )
+            html += %Q(<a href="#{previous_page.url}" class="previous-link">Previous</a> )
           end
           first_skip = false
           second_skip = false
@@ -21,7 +21,7 @@ module Awestruct
             if ( i == current_page_index )
               html += %Q(<span class="current-page">#{i+1}</span> )
             elsif ( i <= window )
-              html += %Q(<a href="#{site.base_url}#{page.url}" class="page-link">#{i+1}</a> )
+              html += %Q(<a href="#{page.url}" class="page-link">#{i+1}</a> )
             elsif ( ( i > window ) && ( i < ( current_page_index - window ) ) && ! first_skip  )
               html += %Q(<span class="skip">...</span>)
               first_skip = true
@@ -29,13 +29,13 @@ module Awestruct
               html += %Q(<span class="skip">...</span>)
               second_skip = true
             elsif ( ( i >= ( current_page_index - window ) ) && ( i <= ( current_page_index + window ) ) )
-              html += %Q(<a href="#{site.base_url}#{page.url}" class="page-link">#{i+1}</a> )
+              html += %Q(<a href="#{page.url}" class="page-link">#{i+1}</a> )
             elsif ( i >= ( ( pages.size - window ) - 1 ) )
-              html += %Q(<a href="#{site.base_url}#{page.url}" class="page-link">#{i+1}</a> )
+              html += %Q(<a href="#{page.url}" class="page-link">#{i+1}</a> )
             end
           end
           unless ( next_page.nil? )
-            html += %Q(<a href="#{site.base_url}#{next_page.url}" class="next-link">Next</a> )
+            html += %Q(<a href="#{next_page.url}" class="next-link">Next</a> )
           end
           html += %Q(</div>)
           html


### PR DESCRIPTION
it seems that the 'site' variable is not available during the call to the links() function.

My fault, I don't understand how I had not seen it before. Sorry about that.
