### PR TITLE
add s3 deployment

### DIFF
--- a/awestruct.gemspec
+++ b/awestruct.gemspec
@@ -39,6 +39,7 @@ spec = Gem::Specification.new do |s|
     s.add_dependency 'git', '~> 1.2.5'
     s.add_dependency 'htmlcompressor', '~> 0.0.3'
     s.add_dependency 'yui-compressor', '~> 0.9.4'
+    s.add_dependency 'ruby-s3cmd', '~> 0.1.5'
 
     s.add_dependency 'listen', '~> 0.5.0'
     s.add_dependency 'thin', '~> 1.4.1'

--- a/lib/awestruct/deploy/s3_deploy.rb
+++ b/lib/awestruct/deploy/s3_deploy.rb
@@ -1,10 +1,19 @@
 require 'awestruct/deploy/base_deploy'
+require 'ruby-s3cmd'
 
 module Awestruct
   module Deploy
     class S3Deploy < Base
       def initialize( site_config, deploy_config )
         @site_path = site_config.output_dir
+        @bucket = deploy_config['bucket']
+      end
+
+      def publish_site
+        $stdout.puts "Syncing #{@site_path} to bucket #{@bucket}"
+        s3cmd = RubyS3Cmd::S3Cmd.new
+        s3cmd.sync("#{@site_path}/", @bucket)
+        $stdout.puts "DONE"
       end
     end
   end

--- a/spec/deploy_spec.rb
+++ b/spec/deploy_spec.rb
@@ -23,6 +23,11 @@ describe Awestruct::CLI::Deploy do
     deployer.deploy_type.should == :foo
   end
 
+  it "should use s3 if deploy['type'] is s3" do
+    deployer = Awestruct::CLI::Deploy.new({}, {'type' => :s3})
+    deployer.deploy_type.should == :s3
+  end
+
   it "should work with strings for keys" do
     deployer = Awestruct::CLI::Deploy.new({}, {'host' => :github_pages})
     deployer.deploy_type.should == :github_pages


### PR DESCRIPTION
- add deployment to Amazon s3 using ruby-s3cmd gem
- the S3 configuration is controlled by the profiles' deploy section which must have `type: s3` and a `bucket` corresponding to the S3 bucket to deploy to.

``` yaml
  profiles:
    staging:
      deploy:
        type: s3
        bucket: s3://staging.jmesnil.net/
    production:
      deploy:
        type: s3
        bucket: s3://jmesnil.net/
```
- The deployment to s3 is using the sync command
