### PR TITLE
Removing the need for thin

### DIFF
--- a/awestruct.gemspec
+++ b/awestruct.gemspec
@@ -38,7 +38,7 @@ spec = Gem::Specification.new do |s|
     s.add_dependency 'ruby-s3cmd', '~> 0.1.5'
 
     s.add_dependency 'listen', '~> 0.5.0'
-    s.add_dependency 'thin', '~> 1.4.1'
+    s.add_dependency 'rack', '~> 1.5.2'
     s.add_dependency 'eventmachine', '~> 1.0.0.rc.4'
 end
 

--- a/lib/awestruct/cli/server.rb
+++ b/lib/awestruct/cli/server.rb
@@ -1,13 +1,9 @@
-#require 'webrick'
-require 'thin'
+require 'rack'
+require 'rack/server'
 require 'awestruct/rack/app'
 
 module Awestruct
   module CLI
-
-    #WEBrick::HTTPUtils::DefaultMimeTypes.store('atom', 'application/atom+xml')
-    #WEBrick::HTTPUtils::DefaultMimeTypes.store('appcache', 'text/cache-manifest')
-
     class Server
       attr_reader :server
 
@@ -18,14 +14,11 @@ module Awestruct
       end
 
       def run
-        @server = Thin::Server.new( '0.0.0.0', @port, Awestruct::Rack::App.new( @path ) )
-        @server.start
-      end
-
-      def run_webrick
-        @server = WEBrick::HTTPServer.new( :DocumentRoot=>@path, :Port=>@port, :BindAddress=>@bind_addr )
-        @server.start
-      end
+        ::Rack::Server::start( :app => Awestruct::Rack::App.new( @path ),
+                              :Port => @port,
+                              :Host => @bind_addr
+                             )
+      end 
     end
   end
 end


### PR DESCRIPTION
Since we already had a rack app file, this just removes thin and lets Rack choose the server, defaults to webbrick.
