### PR TITLE
Remove duplicate version in gemspec, update version constant

### DIFF
--- a/awestruct.gemspec
+++ b/awestruct.gemspec
@@ -9,7 +9,6 @@ spec = Gem::Specification.new do |s|
     s.summary        =   "Static site-baking utility"
     s.description    =   "Awestruct is a framework for creating static HTML sites."
     s.homepage       =   "http://awestruct.org"
-    s.version        =   "0.5.0"
     s.files          =   [
       Dir['lib/**/*.rb'],
       Dir['lib/**/*.haml'],

--- a/lib/awestruct/version.rb
+++ b/lib/awestruct/version.rb
@@ -1,4 +1,4 @@
 
 module Awestruct
-  VERSION='0.4.7'
+  VERSION='0.5.0'
 end


### PR DESCRIPTION
The awestruct executable was reporting a different version than the gem manifest. Align the version on the version constant and update its value to 0.5.0.
