### PR TITLE
Do not fail on loading optional extensions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,8 @@ group :test do
   gem 'RedCloth', '~> 4.2.9'
   gem 'mustache', '~> 0.99.4'
   gem 'uglifier', '~> 1.3.0'
+  gem 'htmlcompressor', '~> 0.0.3'
+
 end
 
 gemspec

--- a/awestruct.gemspec
+++ b/awestruct.gemspec
@@ -34,8 +34,6 @@ spec = Gem::Specification.new do |s|
     s.add_dependency 'json', '~> 1.6.6'
     s.add_dependency 'rest-client', '~> 1.6.7'
     s.add_dependency 'git', '~> 1.2.5'
-    s.add_dependency 'htmlcompressor', '~> 0.0.3'
-    s.add_dependency 'uglifier', '~> 1.3.0'
     s.add_dependency 'ruby-s3cmd', '~> 0.1.5'
 
     s.add_dependency 'listen', '~> 0.5.0'

--- a/lib/awestruct/extensions/pipeline.rb
+++ b/lib/awestruct/extensions/pipeline.rb
@@ -1,6 +1,10 @@
 
 Dir[ File.join( File.dirname(__FILE__), '*.rb' ) ].each do |f|
-  require f
+  begin
+    require f
+  rescue LoadError => e
+    puts "INFO: Missing required dependency to activate optional built in extension #{File.basename(f)} -> #{e}"
+  end
 end
 
 module Awestruct


### PR DESCRIPTION
htmlcompressor, coffee-script and uglifier are optional
dependencies, but required by the minfiy and coffeescripttransformer.
