### PR TITLE
assign doctitle to title attribute for AsciiDoc files

### DIFF
--- a/lib/awestruct/handlers/asciidoctor_handler.rb
+++ b/lib/awestruct/handlers/asciidoctor_handler.rb
@@ -1,4 +1,3 @@
-
 require 'awestruct/handler_chain'
 require 'awestruct/handlers/base_tilt_handler'
 require 'awestruct/handlers/file_handler'
@@ -47,7 +46,7 @@ module Awestruct
         parse_header()
         types = [String, Numeric, TrueClass, FalseClass, Array]
         @front_matter.merge!(context.page.inject({}) do |hash, (k,v)|
-          hash[k.to_s] = v if not k.to_s.start_with?("__") and types.detect { |t| v.kind_of? t}
+          hash[k.to_s] = v if not k.to_s.start_with?('__') and types.detect { |t| v.kind_of? t }
           hash
         end)
         super
@@ -60,8 +59,8 @@ module Awestruct
         else
           opts[:attributes] = opts[:attributes].merge @front_matter
         end
-        opts[:attributes]["awestruct"] = true
-        opts[:attributes]["awestruct-version"] = Awestruct::VERSION
+        opts[:attributes]['awestruct'] = true
+        opts[:attributes]['awestruct-version'] = Awestruct::VERSION
         opts
       end
 

--- a/lib/awestruct/handlers/template/asciidoc.rb
+++ b/lib/awestruct/handlers/template/asciidoc.rb
@@ -31,9 +31,9 @@ module Tilt
         hash
       end
 
-      filtered["doctitle"] = doc.doctitle
-      filtered["date"] ||= doc.attributes["revdate"] unless doc.attributes["revdate"].nil?
-      filtered["author"] = doc.attributes["author"] unless doc.attributes["author"].nil?
+      filtered['title'] = filtered['doctitle'] = doc.doctitle
+      filtered['date'] ||= doc.attributes['revdate'] unless doc.attributes['revdate'].nil?
+      filtered['author'] = doc.attributes['author'] unless doc.attributes['author'].nil?
 
       filtered
     end

--- a/spec/asciidoc_handler_spec.rb
+++ b/spec/asciidoc_handler_spec.rb
@@ -18,6 +18,7 @@ verify_front_matter = lambda { |output, page|
 verify_headers = lambda { |output, page|
   extend RSpec::Matchers
 
+  page.title.should == 'AsciiDoc'
   page.name.should == 'Awestruct'
   page.tags.should be_a_kind_of(Array)
   page.tags.should == %w(a b c)


### PR DESCRIPTION
- also switch to single quotes where interpolation is not used
