### PR TITLE
set fonts_dir, fix path in init manifest, upgrade bootstrap

### DIFF
--- a/lib/awestruct/cli/init.rb
+++ b/lib/awestruct/cli/init.rb
@@ -27,7 +27,7 @@ module Awestruct
         if ( @scaffold )
           manifest.copy_file( '_layouts/base.html.haml', 
                               File.join( File.dirname(__FILE__), "/../frameworks/#{scaffold_name}/base_layout.html.haml" ) )
-          if ( File.file? File.join( File.dirname(__FILE__), "/frameworks/#{scaffold_name}/base_index.html.haml" ) )
+          if ( File.file? File.join( File.dirname(__FILE__), "/../frameworks/#{scaffold_name}/base_index.html.haml" ) )
             manifest.copy_file( 'index.html.haml', 
                                 File.join( File.dirname(__FILE__), "/../frameworks/#{scaffold_name}/base_index.html.haml" ) )
           else

--- a/lib/awestruct/cli/manifest.rb
+++ b/lib/awestruct/cli/manifest.rb
@@ -193,6 +193,7 @@ module Awestruct
                   :css_dir=>'_site/stylesheets',
                   :sass_dir=>'stylesheets',
                   :images_dir=>'images',
+                  :fonts_dir=>'fonts',
                   :javascripts_dir=>'javascripts',
                 } )
           cmd.perform

--- a/lib/awestruct/engine.rb
+++ b/lib/awestruct/engine.rb
@@ -234,12 +234,14 @@ module Awestruct
       Compass.configuration.sass_dir        = 'stylesheets'
       
       site.images_dir      = File.join( site.config.output_dir, 'images' )
+      site.fonts_dir       = File.join( site.config.output_dir, 'fonts' )
       site.stylesheets_dir = File.join( site.config.output_dir, 'stylesheets' )
       site.javascripts_dir = File.join( site.config.output_dir, 'javascripts' )
 
       Compass.configuration.css_dir         = site.css_dir
       Compass.configuration.javascripts_dir = 'javascripts'
       Compass.configuration.images_dir      = 'images'
+      Compass.configuration.fonts_dir       = 'fonts'
       Compass.configuration.line_comments   = include_line_comments?
       Compass.configuration.output_style    = compress_css?
     end

--- a/lib/awestruct/frameworks/bootstrap/base_index.html.haml
+++ b/lib/awestruct/frameworks/bootstrap/base_index.html.haml
@@ -3,7 +3,7 @@ layout: base
 ---
 .hero-unit
   %h1 You're awestruct!
-  %p Your site is all setup to use Twitter Bootstrap with Awestruct.
+  %p This site is all setup to use Twitter Bootstrap with Awestruct.
   %p
     %a.btn.btn-primary.btn-large{ :href=>'http://awestruct.org' }
       %i.icon-info-sign.icon-white

--- a/lib/awestruct/frameworks/bootstrap/base_layout.html.haml
+++ b/lib/awestruct/frameworks/bootstrap/base_layout.html.haml
@@ -25,5 +25,5 @@
       %footer
         %p &copy; Organization #{Date.today.year}
     -# Uncomment script tags (remove leading -#) when you're ready to use behaviors
-    -# %script{ :type=>'text/javascript', :src=>'//cdnjs.cloudflare.com/ajax/libs/jquery/1.7.1/jquery.min.js' }
+    -# %script{ :type=>'text/javascript', :src=>'//cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js' }
     -# %script{ :type=>'text/javascript', :src=>"#{site.base_url}/javascripts/bootstrap-collapse.js" }


### PR DESCRIPTION
Setting the font-path is critical if you want to manually add Font Awesome into your site using one of the Font Awesome SASS configurations.

Our custom Bootstrap home page wasn't getting picked up.

I upgraded Bootstrap and jQuery to the latest.
