### PR TITLE
Error throwing exception in JRuby

### DIFF
--- a/lib/awestruct/page.rb
+++ b/lib/awestruct/page.rb
@@ -146,7 +146,7 @@ module Awestruct
           end
         end
         lineinfo = lineno ? " at line #{lineno}" : ''
-        raise StandardError, %(Failed to render #{self.relative_source_path}#{lineinfo}\n#{e.class}: #{e.message.rstrip}), e.backtrace.join("\n")
+        raise StandardError, "ERROR: Failed to render: #{self.relative_source_path}#{lineinfo}\n#{e.class}: #{e.message.rstrip}\n" + e.backtrace.join("\n")
       end
 
       if context.site.config.track_dependencies


### PR DESCRIPTION
When giving 0.5.0.cr a spin on jruby with windows I ran into an issue where the rendering failed due to unrecognized characters because awestruct was detecting ASCII instead of UTF-8. Anyway I received an error message like this

```
backtrace must be Array of String
org/jruby/RubyException.java:95:in `set_backtrace'
V:/jruby-1.7.3/lib/ruby/gems/shared/gems/awestruct-0.5.0.cr/lib/awestruct/page.rb:149:in `rendered_content'
```

The issue is that the message being passed into StandardError is invalid.

This PR fixes it, but I'm not sure if this is the standardized way we want to be building our exception messages.
