### PR TITLE
fix directory redirect code to be compliant, add test

### DIFF
--- a/lib/awestruct/rack/app.rb
+++ b/lib/awestruct/rack/app.rb
@@ -14,8 +14,8 @@ module Awestruct
         if ( File.directory?( fs_path ) )
           if ( ! ( path =~ %r(/$) ) )
             return [ 301,
-                     { :location=>path + '/' },
-                     "Redirecting to: #{path}" ]
+                     { 'location'=>File.join(path, '') },
+                     ["Redirecting to: #{path}"] ]
           elsif ( File.exist?( File.join( fs_path, 'index.html' ) ) )
             fs_path = File.join( fs_path, 'index.html' )
           end

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -15,6 +15,15 @@ describe Awestruct::Rack::App do
     end
   end
 
+  describe "Directory redirect" do
+    it "should redirect to /" do
+      get('/subdir')
+      last_response.headers['location'].should == '/subdir/'
+      last_response.instance_variable_get('@body').should == ['Redirecting to: /subdir']
+      last_response.body.should == 'Redirecting to: /subdir'
+    end
+  end
+
   describe "CSS media type" do
     it "should return text/css" do
       get('/stylesheets/screen.css')

--- a/spec/test-data/subdir/index.html
+++ b/spec/test-data/subdir/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+  <head>
+    <title>Sample page</title>
+  </head>
+  <body>
+    <h1>Sample page</h1>
+  </body>
+</html>
+


### PR DESCRIPTION
Previously, a request for a URL like /subdir was causing an exception because the information in the redirect was non-compliant. That's been fixed and a test has been added.
