### PR TITLE
update rb-inotify version now that java gems are available

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ group :development do
 end
 
 group :test do
-  gem 'rb-inotify', '~> 0.8.8'
+  gem 'rb-inotify', '~> 0.9.0'
   gem 'rack-test'
   gem 'tilt', '~> 1.3.5'
   gem 'coffee-script', '~> 2.2.0'


### PR DESCRIPTION
There is no java gem for ffi > 1.4.0 and the rb-inotify only requires > 0.5.0 so lets fix this to 1.4.0 for now to maintain jruby compatibility

https://github.com/ffi/ffi/issues/257

_Update_ Gems are now avail for java so bumping ver to 0.9.0 for rb-inotify and removing fix for ffi
