### PR TITLE
rescue if execjs is present but runtime is not available

### DIFF
--- a/lib/awestruct/extensions/pipeline.rb
+++ b/lib/awestruct/extensions/pipeline.rb
@@ -3,7 +3,9 @@ Dir[ File.join( File.dirname(__FILE__), '*.rb' ) ].each do |f|
   begin
     require f
   rescue LoadError => e
-    puts "WARNING: Missing required dependency to activate optional built in extension #{File.basename(f)} -> #{e}" 
+    puts "WARNING: Missing required dependency to activate optional built in extension #{File.basename(f)}\n  #{e}"
+  rescue StandardError => e
+    puts "WARNING: Missing runtime configuration to activate optional built in extension #{File.basename(f)}\n  #{e}"
   end
 end
 


### PR DESCRIPTION
Need to catch the runtime not available exception separately because execjs uses a custom exception for this case.
