### PR TITLE
minor upgrade for bootstrap-sass and tilt

### DIFF
--- a/awestruct.gemspec
+++ b/awestruct.gemspec
@@ -22,15 +22,15 @@ spec = Gem::Specification.new do |s|
     s.require_paths  = [ 'lib' ]
     s.has_rdoc       =   true
 
-    s.requirements  << "Any markup languages you are using and it's dependencies" 
+    s.requirements  << "Any markup languages you are using and its dependencies" 
     s.requirements  << "If LESS is used, or some other fixes within tilt, it is required to use Bundler and the :git ref for the tilt gem"
     s.requirements  << "Haml and markdown filters are touchy things. Rdiscount works well if you're running on mri. jRuby should be using haml 4.0.0 with kramdown"
 
     s.add_dependency 'nokogiri', '~> 1.5.6'
-    s.add_dependency 'tilt', '~> 1.3.4'
+    s.add_dependency 'tilt', '~> 1.3.6'
     s.add_dependency 'compass', '~> 0.12.1'
     s.add_dependency 'compass-960-plugin', '~> 0.10.4'
-    s.add_dependency 'bootstrap-sass', '~> 2.3.0.1'
+    s.add_dependency 'bootstrap-sass', '~> 2.3.1.0'
     s.add_dependency 'json', '~> 1.7.7'
     s.add_dependency 'rest-client', '~> 1.6.7'
     s.add_dependency 'git', '~> 1.2.5'


### PR DESCRIPTION
These are both minor releases that contain only bug fixes, but we should align with the latest going into 0.5.0.
