### PR TITLE
set the default encoding to UTF-8

### DIFF
--- a/lib/awestruct/config/default-site.yml
+++ b/lib/awestruct/config/default-site.yml
@@ -1,3 +1,5 @@
+encoding: UTF-8
+
 content_syntax:
   coffee: coffeescript
   md: markdown

--- a/lib/awestruct/handlers/front_matter_handler.rb
+++ b/lib/awestruct/handlers/front_matter_handler.rb
@@ -42,7 +42,10 @@ module Awestruct
         return if ( @parsed_parts && ! delegate.stale? )
 
         full_content = delegate.raw_content
-        full_content.force_encoding(site.encoding) if site.encoding
+
+        #if force_encoding is supported then set to charset defined in site config
+        full_content.force_encoding(site.encoding) if (full_content.respond_to?(:force_encoding) && site.encoding)
+
         yaml_content = ''
 
         dash_lines = 0


### PR DESCRIPTION
Set the default encoding to UTF-8 which is a sensible default. Users can override this in their own site.yml

For example

`encoding: ASCII-8BIT`
