### PR TITLE
resolves #272 add Rakefile to generated site

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,6 @@ group :test do
   gem 'tilt', '~> 1.3.5'
   gem 'coffee-script', '~> 2.2.0'
   gem 'asciidoctor', '>= 0.1.1' # need 0.1.1 for Header support
-  gem 'haml', '~> 4.0.0'
   gem 'slim', '~> 1.3.6'
   gem 'kramdown', '~> 0.14.2'
   gem 'therubyracer', '~> 0.10.0', :platforms => :ruby

--- a/awestruct.gemspec
+++ b/awestruct.gemspec
@@ -26,6 +26,7 @@ spec = Gem::Specification.new do |s|
     s.requirements  << "If LESS is used, or some other fixes within tilt, it is required to use Bundler and the :git ref for the tilt gem"
     s.requirements  << "Haml and markdown filters are touchy things. Rdiscount works well if you're running on mri. jRuby should be using haml 4.0.0 with kramdown"
 
+    s.add_dependency 'haml', '~> 4.0.1'
     s.add_dependency 'nokogiri', '~> 1.5.6'
     s.add_dependency 'tilt', '~> 1.3.6'
     s.add_dependency 'compass', '~> 0.12.1'

--- a/lib/awestruct/cli/init.rb
+++ b/lib/awestruct/cli/init.rb
@@ -10,8 +10,9 @@ module Awestruct
         mkdir( '_layouts' )
         mkdir( '_ext' )
         copy_file( '_ext/pipeline.rb', File.join( File.dirname(__FILE__), '/../frameworks/base_pipeline.rb' ) )
+        copy_file( '.awestruct_ignore', File.join( File.dirname(__FILE__), '/../frameworks/base_awestruct_ignore' ) )
+        copy_file( 'Rakefile', File.join( File.dirname(__FILE__), '/../frameworks/base_Rakefile' ) )
         mkdir( 'stylesheets' )
-        touch_file( '.awestruct_ignore' )
       }
 
       def initialize(dir=Dir.pwd,framework='compass',scaffold=true)

--- a/lib/awestruct/cli/manifest.rb
+++ b/lib/awestruct/cli/manifest.rb
@@ -20,13 +20,15 @@ class Compass::AppIntegration::StandAlone::Installer
 
       Now you're awestruct!
 
-      To generate your site continuous during development, simply run:
+      To generate and run your site in development mode, execute:
 
         awestruct -d
 
-      and visit your site at
+      or, simply:
 
-        http://localhost:4242/
+        rake
+
+      then visit your site at: http://localhost:4242
 
     END
   end

--- a/lib/awestruct/frameworks/base_Rakefile
+++ b/lib/awestruct/frameworks/base_Rakefile
@@ -1,0 +1,194 @@
+# This file is a rake build file. The purpose of this file is to simplify
+# setting up and using Awestruct. It's not required to use Awestruct, though it
+# does save you time (hopefully). If you don't want to use rake, just ignore or
+# delete this file.
+#
+# If you're just getting started, execute this command to install Awestruct and
+# the libraries on which it depends:
+#
+#  rake setup
+#
+# The setup task installs the necessary libraries according to which Ruby
+# environment you are using. If you want the libraries kept inside the project,
+# execute this command instead:
+#
+#  rake setup[local]
+#
+# IMPORTANT: To install gems, you'll need development tools on your machine,
+# which include a C compiler, the Ruby development libraries and some other
+# development libraries as well.
+#
+# There are also tasks for running Awestruct. The build will auto-detect
+# whether you are using Bundler and, if you are, wrap calls to awestruct in
+# `bundle exec`.
+#
+# To run in Awestruct in development mode, execute:
+#
+#  rake
+#
+# To clean the generated site before you build, execute:
+#
+#  rake clean preview
+#
+# To deploy using the production profile, execute:
+#
+#  rake deploy
+#
+# To get a list of all tasks, execute:
+#
+#  rake -T
+#
+# Now you're Awestruct with rake!
+
+$use_bundle_exec = true
+$install_gems = ['awestruct -v "~> 0.5.0"', 'rb-inotify -v "~> 0.9.0"']
+$awestruct_cmd = nil
+task :default => :preview
+
+desc 'Setup the environment to run Awestruct'
+task :setup, [:env] => :init do |task, args|
+  next if !which('awestruct').nil?
+
+  if File.exist? 'Gemfile'
+    if args[:env] == 'local'
+      require 'fileutils'
+      FileUtils.remove_file 'Gemfile.lock', true
+      FileUtils.remove_dir '.bundle', true
+      system 'bundle install --binstubs=_bin --path=.bundle'
+    else
+      system 'bundle install'
+    end
+  else
+    if args[:env] == 'local'
+      $install_gems.each do |gem|
+        msg "Installing #{gem}..."
+        system "gem install --bindir=_bin --install-dir=.bundle #{gem}"
+      end
+    else
+      $install_gems.each do |gem|
+        msg "Installing #{gem}..."
+        system "gem install #{gem}"
+      end
+    end
+  end
+  msg 'Run awestruct using `awestruct` or `rake`'
+  # Don't execute any more tasks, need to reset env
+  exit 0
+end
+
+desc 'Update the environment to run Awestruct'
+task :update => :init do
+  if File.exist? 'Gemfile'
+    system 'bundle update'
+  else
+    system 'gem update awestruct'
+  end
+  # Don't execute any more tasks, need to reset env
+  exit 0
+end
+
+desc 'Build and preview the site locally in development mode'
+task :preview => :check do
+  run_awestruct '-d'
+end
+
+desc 'Generate the site using the development profile'
+task :gen => :check do
+  run_awestruct '-P development -g --force'
+end
+
+desc 'Generate the site and deploy to production'
+task :deploy => :check do
+  run_awestruct '-P development -g --force --deploy'
+end
+
+desc 'Clean out generated site and temporary files'
+task :clean, :spec do |task, args|
+  require 'fileutils'
+  dirs = ['.awestruct', '.sass-cache', '_site']
+  if args[:spec] == 'all'
+    dirs << '_tmp'
+  end
+  dirs.each do |dir|
+    FileUtils.remove_dir dir unless !File.directory? dir
+  end
+end
+
+# Perform initialization steps, such as setting up the PATH
+task :init do
+  # Detect using gems local to project
+  if File.exist? '_bin'
+    ENV['PATH'] = "_bin#{File::PATH_SEPARATOR}#{ENV['PATH']}"
+    ENV['GEM_HOME'] = '.bundle'
+  end
+end
+
+desc 'Check to ensure the environment is properly configured'
+task :check => :init do
+  if !File.exist? 'Gemfile'
+    if which('awestruct').nil?
+      msg 'Could not find awestruct.', :warn
+      msg 'Run `rake setup` or `rake setup[local]` to install from RubyGems.'
+      # Enable once the rubygem-awestruct RPM is available
+      #msg 'Run `sudo yum install rubygem-awestruct` to install via RPM. (Fedora >= 18)'
+      exit 1
+    else
+      $use_bundle_exec = false
+      next
+    end
+  end
+
+  begin
+    require 'bundler'
+    Bundler.setup
+  rescue LoadError
+    $use_bundle_exec = false
+  rescue StandardError => e
+    msg e.message, :warn
+    if which('awestruct').nil?
+      msg 'Run `rake setup` or `rake setup[local]` to install required gems from RubyGems.'
+    else
+      msg 'Run `rake update` to install additional required gems from RubyGems.'
+    end
+    exit e.status_code
+  end
+end
+
+# Execute Awestruct
+def run_awestruct(args)
+  system "#{$use_bundle_exec ? 'bundle exec ' : ''}awestruct #{args}" 
+end
+
+# A cross-platform means of finding an executable in the $PATH.
+# Respects $PATHEXT, which lists valid file extensions for executables on Windows
+#
+#  which 'awestruct'
+#  => /usr/bin/awestruct
+def which(cmd, opts = {})
+  unless $awestruct_cmd.nil? || opts[:clear_cache]
+    return $awestruct_cmd
+  end
+
+  $awestruct_cmd = nil
+  exts = ENV['PATHEXT'] ? ENV['PATHEXT'].split(';') : ['']
+  ENV['PATH'].split(File::PATH_SEPARATOR).each do |path|
+    exts.each do |ext|
+      candidate = File.join path, "#{cmd}#{ext}"
+      if File.executable? candidate
+        $awestruct_cmd = candidate
+        return $awestruct_cmd
+      end
+    end
+  end
+  return $awestruct_cmd
+end
+
+# Print a message to STDOUT
+def msg(text, level = :info)
+  case level
+  when :warn
+    puts "\e[31m#{text}\e[0m"
+  else
+    puts "\e[33m#{text}\e[0m"
+  end
+end

--- a/lib/awestruct/frameworks/base_awestruct_ignore
+++ b/lib/awestruct/frameworks/base_awestruct_ignore
@@ -1,0 +1,2 @@
+Gemfile*
+Rakefile


### PR DESCRIPTION
- add a Rakefile to the generated site to simplify setup and execution
- add a dependency on haml since it's needed to run the generated site
- add default .awestruct_ignore to ignore Gemfile\* and Rakefile
