### PR TITLE
include rb-fsevent in gemfile

### DIFF
--- a/lib/awestruct/frameworks/base_Gemfile
+++ b/lib/awestruct/frameworks/base_Gemfile
@@ -27,6 +27,7 @@ source 'https://rubygems.org'                             # This tells Bundler w
 gem 'awestruct', '>= 0.5.1'                               # Goes without saying
 gem 'rake', '>= 0.9.2'                                    # Needed for the Rakefile to work
 # gem 'coffee-script', '>= 2.2.0'                         # If using coffee-script or to remove the warning
+# gem 'rb-fsevent', '~> 0.9'                              # to remove warning
 # gem 'therubyracer', '0.10.0', :platforms => :ruby       # Javascript runtime on mri (needed for LESS and coffee-script)
 # gem 'therubyrhino', '~> 2.0.2', :platforms => :jruby    # Javascript runtime on jruby (needed for LESS and coffee-script)
 # gem 'less', '>= 2.2.2'                                  # If using LESS instead of sass 


### PR DESCRIPTION
if I don't have gem 'rb-fsevent', '~> 0.9' in my gemfile I get this warning:

Listen warning]:
  Missing dependency 'rb-fsevent' (version '~> 0.9')!
  Please add the following to your Gemfile to satisfy the dependency:
    gem 'rb-fsevent', '~> 0.9'

  For a better performance, it's recommended that you satisfy the missing dependency.
  Listen will be polling changes. Learn more at https://github.com/guard/listen#polling-fallback.

not sure why so I suggest it gets added in or at least documented
