### PR TITLE
Shellwords.escape() adds \ after pngcrush\ binary

### DIFF
--- a/lib/awestruct/extensions/minify.rb
+++ b/lib/awestruct/extensions/minify.rb
@@ -117,7 +117,7 @@ module Awestruct
 
       def pngcrush(page, input)
         filename = page.source_path
-        cmd = Shellwords.escape("pngcrush #{filename} /tmp/pngcrush")
+        cmd = "pngcrush " + Shellwords.escape("#{filename}") + " /tmp/pngcrush"
         `#{cmd}`
         if $?.exitstatus != 0
           raise "Failed to execute pngcrush: #{cmd}"


### PR DESCRIPTION
Use `Shellwords.escape()` only on the dynamic parameter `#{filename}` to avoid file not found on `pngcrush\`

Environment : 
Ubuntu 12.04.2 LTS
Awestruct 0.5.2
