### PR TITLE
Make relative a noop for absolute links

### DIFF
--- a/lib/awestruct/extensions/relative.rb
+++ b/lib/awestruct/extensions/relative.rb
@@ -6,7 +6,13 @@ module Awestruct
 
       def relative(href, p = page)
         begin
-          Pathname.new(href).relative_path_from(Pathname.new(File.dirname(p.output_path))).to_s
+          # Ignore absolute links
+          if href.start_with?("http://") || href.start_with?("https://")
+            result = href
+          else
+            result = Pathname.new(href).relative_path_from(Pathname.new(File.dirname(p.output_path))).to_s
+          end
+          result
         rescue Exception => e
           $LOG.error "#{e}" if $LOG.error?
           $LOG.error "#{e.backtrace.join("\n")}" if $LOG.error?


### PR DESCRIPTION
Links are considered absolute when they start with http:// or https://
