### PR TITLE
Fix IntenseDebate comment URLs once and for all

### DIFF
--- a/lib/awestruct/extensions/intense_debate.rb
+++ b/lib/awestruct/extensions/intense_debate.rb
@@ -26,7 +26,7 @@ module Awestruct
           html = %Q(<script>\n)
           html += %Q(  var idcomments_acct='#{site.intense_debate_acct}';\n)
           html += %Q(  var idcomments_post_id='#{post_id}';\n )
-          html += %Q(  var idcomments_post_url='#{self.url}';\n)
+          html += %Q(  var idcomments_post_url='#{site.intense_debate_base_url || site.base_url}#{self.url}';\n)
           html += %Q(</script>\n)
           html += %Q(<script type='text/javascript' src='http://www.intensedebate.com/js/genericLinkWrapperV2.js'></script>\n)
           html


### PR DESCRIPTION
This copies the URL logic from intense_debate_comments() to intense_debate_comments_link() to finally fix the issue of IntenseDebate comment notification emails containing the wrong link.
