### PR TITLE
Resolves #303 (base deployer requiring git)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ group :test do
   gem 'mustache', '>= 0.99.4'
   gem 'uglifier', '>= 1.3.0'
   gem 'htmlcompressor', '>= 0.0.7'
+  gem 'git', '~> 1.2.5'
 end
 
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,7 @@ if !defined?(RSpec)
 else
   desc "Run all examples"
   RSpec::Core::RakeTask.new(:spec) do |t|
-    t.pattern = 'spec/*_spec.rb'
+    t.pattern = 'spec/**/*_spec.rb'
     t.rspec_opts = ['-cfs']
   end
 end

--- a/awestruct.gemspec
+++ b/awestruct.gemspec
@@ -31,7 +31,6 @@ spec = Gem::Specification.new do |s|
     s.add_dependency 'bootstrap-sass', '>= 2.3.1.0'
     s.add_dependency 'zurb-foundation', '>= 4.0.9'
     s.add_dependency 'rest-client', '>= 1.6.7'
-    s.add_dependency 'git', '~> 1.2.5'
     s.add_dependency 'ruby-s3cmd', '~> 0.1.5'
 
     s.add_dependency 'listen', '>= 0.7.3'

--- a/lib/awestruct/deploy/base_deploy.rb
+++ b/lib/awestruct/deploy/base_deploy.rb
@@ -1,20 +1,26 @@
 require 'awestruct/deployers'
-require 'git'
+Dir[ File.join( File.dirname(__FILE__), '..', 'scm' '*.rb' ) ].each do |f|
+  begin
+    require f
+  rescue LoadError => e
+    raise e 'Something horribly, horribly wrong has happened'
+  end
+end
+
 
 module Awestruct
   module Deploy
     class Base
-      UNCOMMITTED_CHANGES = "You have uncommitted changes in the working branch. Please commit or stash them."
+      UNCOMMITTED_CHANGES = 'You have uncommitted changes in the working branch. Please commit or stash them.'
       def run(deploy_config)
         if deploy_config['uncommitted'] == true
           publish_site
         else
-          git.status.changed.empty? ? publish_site : existing_changes
+          scm = deploy_config['scm'] || 'git'
+          #require "awestruct/scm/#{scm}"
+          scm_class = Object.const_get('Awestruct').const_get('Scm').const_get(scm.slice(0, 1).capitalize + scm.slice(1..-1))
+          scm_class.new.uncommitted_changes?(deploy_config['source_dir']) ? existing_changes() : publish_site()
         end
-      end
-
-      def git
-        @git ||= ::Git.open('.')
       end
 
       def publish_site

--- a/lib/awestruct/deploy/github_pages_deploy.rb
+++ b/lib/awestruct/deploy/github_pages_deploy.rb
@@ -1,12 +1,13 @@
 require 'awestruct/deploy/base_deploy'
+require 'git'
 
 module Awestruct
   module Deploy
     class GitHubPagesDeploy < Base
-      def initialize( site_config, deploy_config )
+      def initialize(site_config, deploy_config)
         @site_path = site_config.output_dir
-        @branch    = deploy_config[ 'branch' ] || 'gh-pages'
-        @repo      = deploy_config[ 'repository' ] || 'origin'
+        @branch = deploy_config['branch'] || 'gh-pages'
+        @repo = deploy_config['repository'] || 'origin'
       end
 
       def publish_site
@@ -16,15 +17,15 @@ module Awestruct
         if current_branch == '(no branch)'
           current_branch = git.revparse('HEAD')
         end
-        git.branch( @branch ).checkout
+        git.branch(@branch).checkout
         add_and_commit_site @site_path
-        git.push( @repo, @branch )
-        git.checkout( current_branch )
+        git.push(@repo, @branch)
+        git.checkout(current_branch)
       end
 
       private
-      def add_and_commit_site( path )
-        git.with_working( path ) do
+      def add_and_commit_site(path)
+        git.with_working(path) do
           git.add(".")
           begin
             git.commit("Published #{@branch} to GitHub pages.")
@@ -34,8 +35,12 @@ module Awestruct
         end
         git.reset_hard
       end
+
+      def git
+        @git ||= ::Git.open('.')
+      end
     end
   end
 end
 
-Awestruct::Deployers.instance[ :github_pages ] = Awestruct::Deploy::GitHubPagesDeploy
+Awestruct::Deployers.instance[:github_pages] = Awestruct::Deploy::GitHubPagesDeploy

--- a/lib/awestruct/scm/git.rb
+++ b/lib/awestruct/scm/git.rb
@@ -1,0 +1,14 @@
+require 'open3'
+
+module Awestruct
+  module Scm
+    class Git
+      def uncommitted_changes?(source_dir)
+        result = Open3.popen3('git status --porcelain', :chdir => source_dir) do |stdin, stdout, stderr, wait_thr|
+          stdout.read.chomp =~ /^\s*([AM?]+)/
+        end
+        !result.nil?
+      end
+    end
+  end
+end

--- a/spec/awestruct/scm/git_spec.rb
+++ b/spec/awestruct/scm/git_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+require 'awestruct/scm/git'
+
+describe Awestruct::Scm::Git do
+  specify 'should respond_to :uncommitted_changes?' do
+    expect(subject).to respond_to :uncommitted_changes?
+  end
+  context "#uncommitted_changes?('.')" do
+    specify 'when there are no changes, returns false' do
+      Open3.should_receive(:popen3).with('git status --porcelain', :chdir => '.').and_yield(nil, StringIO.new(''), StringIO.new(''), nil)
+      expect(subject.uncommitted_changes? '.').to be_false
+    end
+
+    specify 'when there are changes to untracked files, returns true' do
+      Open3.should_receive(:popen3).with('git status --porcelain', :chdir => '.').and_yield(nil, StringIO.new('?? test.rb'), StringIO.new(''), nil)
+      expect(subject.uncommitted_changes? '.').to be_true
+    end
+
+    specify 'when there are modifications, returns true' do
+      Open3.should_receive(:popen3).with('git status --porcelain', :chdir => '.').and_yield(nil, StringIO.new(' M test.rb'), StringIO.new(''), nil)
+      expect(subject.uncommitted_changes? '.').to be_true
+    end
+
+    specify 'when there are additions and modifications, returns true' do
+      Open3.should_receive(:popen3).with('git status --porcelain', :chdir => '.').and_yield(nil, StringIO.new('AM test.rb'), StringIO.new(''), nil)
+      expect(subject.uncommitted_changes? '.').to be_true
+    end
+  end
+end

--- a/spec/github_pages_deploy_spec.rb
+++ b/spec/github_pages_deploy_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+require 'awestruct/scm/git'
 require 'awestruct/deploy/github_pages_deploy'
 
 describe Awestruct::Deploy::GitHubPagesDeploy do
@@ -9,6 +11,8 @@ describe Awestruct::Deploy::GitHubPagesDeploy do
     @deploy_config = mock
     @deploy_config.stub(:[]).with('branch').and_return('the-branch')
     @deploy_config.stub(:[]).with('repository').and_return('the-repo')
+    @deploy_config.stub(:[]).with('scm').and_return('git')
+    @deploy_config.stub(:[]).with('source_dir').and_return('.')
     @deploy_config.stub(:[]).with('uncommitted').and_return('false')
     @deployer = Awestruct::Deploy::GitHubPagesDeploy.new( site_config, @deploy_config )
 
@@ -21,19 +25,18 @@ describe Awestruct::Deploy::GitHubPagesDeploy do
     Awestruct::Deployers.instance[ :github_pages ].should == Awestruct::Deploy::GitHubPagesDeploy
   end
 
-  it "should publish the site if there have been changes to the git repo" do
-    ::Git.should_receive(:open).with('.').and_return @git
-    @deployer.should_receive(:publish_site)
-    @deployer.run(@deploy_config)
-  end
-
   it "should warn and noop if no changes have been committed" do
-    @git.stub_chain(:status, :changed, :empty?).and_return false
+    git_scm = mock()
+    git_scm.stub(:uncommitted_changes?).with('.').and_return true
+    ::Awestruct::Scm::Git.stub(:new).and_return git_scm
     $LOG.should_receive(:error).with(Awestruct::Deploy::Base::UNCOMMITTED_CHANGES)
     @deployer.run(@deploy_config)
   end
 
   it "should save and restore the current branch when publishing" do
+    git_scm = mock()
+    git_scm.stub(:uncommitted_changes?).with('.').and_return false
+    ::Awestruct::Scm::Git.stub(:new).and_return git_scm
     @git.should_receive(:current_branch).and_return( 'bacon' )
     @git.stub_chain(:branch, :checkout)
     @git.should_receive(:push).with('the-repo', 'the-branch')
@@ -44,6 +47,9 @@ describe Awestruct::Deploy::GitHubPagesDeploy do
   end
 
   it "should save and restore the current detached branch when publishing" do
+    git_scm = mock()
+    git_scm.stub(:uncommitted_changes?).with('.').and_return false
+    ::Awestruct::Scm::Git.stub(:new).and_return git_scm
     @git.should_receive(:current_branch).and_return( '(no branch)' )
     @git.should_receive(:revparse).with( 'HEAD' ).and_return( '0123456789' )
     @git.stub_chain(:branch, :checkout)


### PR DESCRIPTION
This also abstracts out the status check from any gem and makes the git gem optional (depending on the github pages deployer).
