### PR TITLE
Add Console for live query of Page/Site data #211

### DIFF
--- a/lib/awestruct/cli/console.rb
+++ b/lib/awestruct/cli/console.rb
@@ -1,0 +1,122 @@
+require 'awestruct/engine'
+
+module Awestruct
+  module CLI
+    class Console
+
+      def run()
+
+        puts "Query Console ready.."
+        print "$> "
+        STDOUT.flush
+        begin
+          while(input = STDIN.gets)
+            begin
+              execute( input )
+            rescue => e
+              puts e
+              puts e.backtrace
+            end
+          end
+        rescue SystemExit, Interrupt
+          exit
+        end
+
+      end
+
+      def get_pages
+        Awestruct::Engine.instance.site.pages
+      end
+
+      def execute(query_expression, out = STDOUT)
+        return if query_expression.strip.empty?
+        query = Query.new( query_expression )
+
+        if(query.page.source.eql? 'site')
+          query.run( out, Awestruct::Engine.instance.site )
+        else
+          query.run( out, *get_pages )
+        end
+
+        out.puts
+        out.print "$> "
+        out.flush
+      end
+    end
+
+    class Query
+      attr_reader :page
+      attr_reader :field
+      attr_reader :field_full_value
+      attr_reader :deps
+
+      def initialize( expression )
+        types = expression.split(":")
+        page = types[0].strip
+        if types.size > 1
+          if "<>".include? types[1].strip
+            @deps = types[1].strip
+          else
+            field = types[1].strip
+          end
+        end
+        if types.size > 2
+          @deps = types[1]
+        end
+
+        if field =~ /!$/
+          @field_full_value = true
+          field.chop!
+        else
+          @field_full_value = false
+        end
+
+        @page = Regexp.new page.gsub( "*", ".*" )
+        @field = Regexp.new field.gsub( "*", ".*" ) unless field.nil?
+      end
+
+      def run(out, *pages)
+        out.puts "Query for Page[#{@page.source}] with Field[#{@field.source unless @field.nil?}] and Dependencies[#{@deps}]"
+        out.puts "----------------------------------------------------------------------------------------------------------"
+        pages.each do |p|
+          if @page.source.eql? 'site' or p.output_path =~ @page
+            out.puts "#{p.output_path}"
+
+            unless @field.nil?
+              p.keys.each do |f|
+                out.puts "\t #{f} -> #{format_field(p[f], @field_full_value)}" if f.to_s =~ @field
+              end
+            end
+
+            unless @deps.nil?
+              if @deps.eql? ">"
+                if @field.nil?
+                  p.dependencies.dependencies.each do |d|
+                    out.puts "\t > #{d.output_path}"
+                  end
+                end
+              elsif @deps.eql? "<"
+                if @field.nil?
+                  p.dependencies.dependents.each do |d|
+                    out.puts "\t < #{d.output_path}"
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+
+      def format_field(field, field_full_value)
+        return field.inspect if field_full_value
+
+        val = field.inspect[0..80]
+        if val.size >= 80
+          val = val + "..."
+        end
+        return val
+      end
+    end
+
+  end
+end

--- a/lib/awestruct/cli/invoker.rb
+++ b/lib/awestruct/cli/invoker.rb
@@ -4,6 +4,8 @@ require 'awestruct/cli/init'
 require 'awestruct/cli/generate'
 require 'awestruct/cli/auto'
 require 'awestruct/cli/server'
+require 'awestruct/cli/deploy'
+require 'awestruct/cli/console'
 require 'awestruct/logger'
 
 require 'pathname'
@@ -48,6 +50,7 @@ module Awestruct
         invoke_deploy()    if ( options.deploy )
         invoke_server()    if ( options.server )
         invoke_auto()      if ( options.auto )
+        invoke_console()   if ( options.console )
 
         wait_for_completion()
         success
@@ -124,6 +127,9 @@ module Awestruct
         run_in_thread( Awestruct::CLI::Server.new( './_site', options.bind_addr, options.port ) )
       end
 
+      def invoke_console()
+        run_in_thread( Awestruct::CLI::Console.new )
+      end
 
       private
 

--- a/lib/awestruct/cli/options.rb
+++ b/lib/awestruct/cli/options.rb
@@ -21,6 +21,7 @@ module Awestruct
       attr_accessor :deploy
       attr_accessor :script
       attr_accessor :verbose
+      attr_accessor :console
 
       def initialize()
         @generate  = nil
@@ -37,6 +38,7 @@ module Awestruct
         @deploy    = false
         @script    = nil
         @verbose   = false
+        @console   = false
       end
 
       def self.parse!(args)
@@ -98,6 +100,9 @@ module Awestruct
           #opts.on( '--run SCRIPT', 'Invoke a script after initialization' ) do |script|
           #  self.script = script
           #end
+          opts.on( '--console', 'Launch the interactive console' ) do |console|
+            self.console = console if self.auto
+          end
       
           opts.separator ''
           opts.separator "Common options:"

--- a/spec/console_spec.rb
+++ b/spec/console_spec.rb
@@ -1,0 +1,96 @@
+require 'awestruct/cli/console'
+require 'awestruct/astruct'
+require 'spec_helper'
+require 'stringio'
+
+describe Awestruct::CLI::Console do
+
+
+  # query format: pageexp[:field][:depoperator]
+  # blogs:title:<  <-- show all dependents on title for pages that match blogs*
+  # blogs:title:>  <-- show all dependents on title for pages that match blogs*
+
+  before :all do
+
+    pages = []
+    pages << Awestruct::AStruct.new({"output_path" => "/blog/page1.html", "title" => "Page 1 Blog"})
+    pages << Awestruct::AStruct.new({"output_path" => "/blog/page2.html", "title" => "Page 2 Blog"})
+    pages << Awestruct::AStruct.new({"output_path" => "/blog/page3.html", "title" => "Page 3 Blog"})
+    pages << Awestruct::AStruct.new({"output_path" => "/blog/page4.html", "author" => "Page 4 Author"})
+
+    pages[0].dependencies = Awestruct::AStruct.new({"dependents" => [] , "dependencies" => [] << pages[1]})
+    pages[1].dependencies = Awestruct::AStruct.new({"dependents" => [] << pages[0], "dependencies" => []})
+    pages[2].dependencies = Awestruct::AStruct.new({"dependents" => [], "dependencies" => []})
+
+    @console = TestConsole.new pages
+  end
+
+  it "should find all pages" do
+    output = StringIO.new
+    @console.execute("page1", output)
+
+    output.seek(0)
+    result = output.read
+    result.should =~ %r(/blog/page1.html)
+  end
+
+  it "should find all variables" do
+    output = StringIO.new
+    @console.execute(":titl", output)
+
+    output.seek(0)
+    result = output.read
+    result.should =~ %r(/blog/page1.html)
+    result.should =~ %r(title -> "Page 1 Blog")
+    result.should =~ %r(/blog/page2.html)
+    result.should =~ %r(title -> "Page 2 Blog")
+    result.should =~ %r(/blog/page3.html)
+    result.should =~ %r(title -> "Page 3 Blog")
+  end
+
+  it "should find all pages and variables" do
+    output = StringIO.new
+    @console.execute("page1:tit", output)
+
+    output.seek(0)
+    result = output.read
+    result.should =~ %r(/blog/page1.html)
+    result.should =~ %r(title -> "Page 1 Blog")
+  end
+
+  it "should find all pages dependencies" do
+    output = StringIO.new
+    @console.execute("page1:>", output)
+
+    output.seek(0)
+    result = output.read
+    result.should =~ %r(/blog/page1.html)
+    result.should =~ %r(> /blog/page2.html)
+  end
+
+  it "should find all pages dependents" do
+    output = StringIO.new
+    @console.execute("page2:<", output)
+
+    output.seek(0)
+    result = output.read
+    result.should =~ %r(/blog/page2.html)
+    result.should =~ %r(< /blog/page1.html)
+  end
+
+  it "should find all pages variable dependencies < makes sense?"
+
+  it "should find all pages variable dependents < makes sense?"
+
+end
+
+class TestConsole < Awestruct::CLI::Console
+
+  def initialize(pages)
+    @pages = pages
+  end
+
+  def get_pages
+    @pages
+  end
+end


### PR DESCRIPTION
Query console supports searching and viewing page relations, page variables
and site variables.

pageexp[:field|depoperator]

_pageexp_ and _field_ values are handled as Regular Expression and matched
against page.output_path and page[*] variables.

'site' is handled as a special pagexp and can be used to search for values
on the site object.

_depoperator_ can have the value > for listing dependencies to list the
pages that depend on the page the match the _pageexp_, or < to list the
dependents.

Example:

$> page1:<

page1
 < page2

$> page1:title

page1
  title -> 'X'

Activate console by using cli option --console

Issue: #211