### PR TITLE
Ability to add headers on files for S3 deployment

### DIFF
--- a/awestruct.gemspec
+++ b/awestruct.gemspec
@@ -37,7 +37,6 @@ Haml and Markdown filters are touchy things. Redcarpet or Rdiscount work well if
   s.add_dependency 'tilt', '~> 2.0', '>= 2.0.1'
   s.add_dependency 'mime-types', '~> 2.1'
   s.add_dependency 'rest-client', '~> 1.7', '>= 1.7.2'
-  s.add_dependency 'ruby-s3cmd', '~> 0.1', '>= 0.1.5'
   s.add_dependency 'listen', '~> 2.7', '>= 2.7.1'
   s.add_dependency 'rack', '~> 1.5', '>= 1.5.2'
   s.add_dependency 'git', '~> 1.2', '>= 1.2.6'

--- a/lib/awestruct/deploy/s3_deploy.rb
+++ b/lib/awestruct/deploy/s3_deploy.rb
@@ -1,5 +1,4 @@
 require 'awestruct/deploy/base_deploy'
-require 'ruby-s3cmd'
 
 module Awestruct
   module Deploy
@@ -7,13 +6,52 @@ module Awestruct
       def initialize( site_config, deploy_config )
         super
         @bucket = deploy_config['bucket']
+        @metadata = deploy_config['metadata']
       end
 
       def publish_site
         $LOG.info "Syncing #{@site_path} to bucket #{@bucket}" if $LOG.info?
-        s3cmd = RubyS3Cmd::S3Cmd.new
-        s3cmd.sync("#{@site_path}/", @bucket)
+        if @metadata and !@metadata.empty?
+          @metadata.each do |fileType, headers|
+            # Build the add-header command because the s3cmd-dsl gem doesn't support multi-headers
+            headerCmd = ""
+            if headers && !headers.empty?
+              headers.each do |key, value|
+                headerCmd << add_header(key, value)
+              end
+            end
+            # If gzip is enabled, add 'Content-Encoding: gzip' on js, css and html files
+            if @gzip and ['js', 'css', 'html'].include? fileType
+              headerCmd << add_header("Content-Encoding", "gzip")
+            end
+            # Sync files of current type with specified headers
+            s3_sync(@site_path, @bucket, "*", "*.#{fileType}", headerCmd)
+          end
+        end
+        # If gzip is enabled, add 'Content-Encoding: gzip' on not processed js, css and html files
+        if @gzip
+          remainingFileType = ['js', 'css', 'html'].find_all { |fileType| !@metadata.keys.include? fileType }
+          remainingFileType.each do |fileType|
+            headerCmd = add_header("Content-Encoding", "gzip")
+            s3_sync(@site_path, @bucket, "*", "*.#{fileType}", headerCmd)
+          end
+        end
+        # Finally, sync others files
+        s3_sync(@site_path, @bucket)
         $LOG.info "DONE" if $LOG.info?
+      end
+
+      def add_header(key, value)
+        " --add-header '#{key}:#{value}'"
+      end
+
+      def s3_sync(site_path, bucket, exclude = nil, include = nil, headersCmd = nil)
+        cmd="s3cmd sync '#{site_path}' '#{bucket}'"
+        cmd << " --exclude '#{exclude}'" if exclude
+        cmd << " --include '#{include}'" if include
+        cmd << " #{headersCmd}" if headersCmd
+        $LOG.info "Execute #{cmd}"
+        `#{cmd}`
       end
     end
   end


### PR DESCRIPTION
Usage:
```yaml
profiles:
  production:
    deploy:
      type: s3
      bucket: s3://awestruct.org
      gzip: true
      metadata:
        jpg:
          Cache-Control: max-age=2592000
        jpeg:
          Cache-Control: max-age=2592000
        png:
          Cache-Control: max-age=2592000
        css:
          Cache-Control: max-age=31536000
        js:
          Cache-Control: max-age=31536000
```

The above configuration will produce the following commands:
```sh
s3cmd sync '_site/' 's3://awestruct.org' --exclude '*' --include '*.jpg'  --add-header 'Cache-Control:max-age=2592000'
s3cmd sync '_site/' 's3://awestruct.org' --exclude '*' --include '*.jpeg'  --add-header 'Cache-Control:max-age=2592000'
s3cmd sync '_site/' 's3://awestruct.org' --exclude '*' --include '*.png'  --add-header 'Cache-Control:max-age=2592000'
s3cmd sync '_site/' 's3://awestruct.org' --exclude '*' --include '*.css'  --add-header 'Cache-Control:max-age=31536000' --add-header 'Content-Encoding:gzip'
s3cmd sync '_site/' 's3://awestruct.org' --exclude '*' --include '*.js'  --add-header 'Cache-Control:max-age=31536000' --add-header 'Content-Encoding:gzip'
s3cmd sync '_site/' 's3://awestruct.org' --exclude '*' --include '*.html'  --add-header 'Content-Encoding:gzip'
s3cmd sync '_site/' 's3://awestruct.org'
```

If we use `gzip` option, Awestruct will automatically add a `Content-Encoding:gzip` option on js, css and html files.

As a side note I removed the dependency on ruby-s3cmd or else, I should have done too much workaround to add multiple headers. The command line is quite simple to construct so I think there is no need to add a dependency.

