### PR TITLE
resolves #362 use neutral attribute prefixes in AsciiDoc integration

### DIFF
--- a/spec/asciidoc_handler_spec.rb
+++ b/spec/asciidoc_handler_spec.rb
@@ -22,7 +22,7 @@ verify_headers = lambda { |output, page|
   page.tags.should be_a_kind_of(Array)
   page.tags.should == %w(a b c)
   page.date.should be_a_kind_of(Date)
-  output.should =~ %r(This is <strong>AsciiDoc</strong> in Awestruct.)
+  output.should =~ %r(This is <strong>AsciiDoc</strong> page named Awestruct in an Awestruct site.)
   output.should =~ %r(#{Awestruct::VERSION})
   output.should =~ %r(UTF-8)
 }

--- a/spec/test-data/handlers/asciidoctor_with_headers.ad
+++ b/spec/test-data/handlers/asciidoctor_with_headers.ad
@@ -1,10 +1,12 @@
 = AsciiDoc
 Stuart Rackham
 2013-02-06
-:awestruct-tags: [a, b, c]
-:awestruct-layout: haml-layout
+:page-tags: [a, b, c]
+:page-layout: haml-layout
 :name: NOT_HANDLED
+:site-test: preserved
 
-This is *AsciiDoc* in {name}.
+This is *AsciiDoc* page named {page-name} in an Awestruct site.
 {awestruct-version}
-{site_encoding}
+{site-encoding}
+{site-test}


### PR DESCRIPTION
- use page- prefix instead of awestruct- prefix for front matter
- retain support for awestruct- prefix, but consider deprecated
- write page variables to attributes prefixed with page-
- write selected site variables to attributes prefixed with site-
