### PR TITLE
resolves #290 interpolation for AsciiDoc files, page-scoped interpolation

### DIFF
--- a/lib/awestruct/handlers/interpolation_handler.rb
+++ b/lib/awestruct/handlers/interpolation_handler.rb
@@ -13,7 +13,7 @@ module Awestruct
         content = delegate.raw_content
 
         return nil if content.nil?
-        return content unless site.interpolate
+        return content unless front_matter.fetch('interpolate', site.interpolate)
 
         content = content.gsub( /\\/, '\\\\\\\\' )
         content = content.gsub( /\\\\#/, '\\#' )

--- a/spec/asciidoc_handler_spec.rb
+++ b/spec/asciidoc_handler_spec.rb
@@ -34,6 +34,18 @@ verify_attributes = lambda { |output, page|
   expect(output).to RSpec::Matchers::BuiltIn::Include.new("docdir=#{File.expand_path File.dirname(page.source_path)};")
 }
 
+verify_interpolation = lambda { |output, page|
+  extend RSpec::Matchers
+  output.should =~ %r(UTF-8)
+  page.site.interpolate.should == true
+}
+
+verify_no_interpolation = lambda { |output, page|
+  extend RSpec::Matchers
+  output.should =~ %r(\#\{site\.encoding\})
+  page.site.interpolate.should == true
+}
+
 theories =
     [
         {
@@ -77,6 +89,22 @@ theories =
             :syntax => :asciidoc,
             :extension => '.html',
             :matcher => verify_attributes
+        },
+        {
+            :page => 'asciidoc_with_interpolation.ad',
+            :simple_name => 'asciidoc_with_interpolation',
+            :syntax => :asciidoc,
+            :extension => '.html',
+            :matcher => verify_interpolation,
+            :site_overrides => { :interpolate => true }
+        },
+        {
+            :page => 'asciidoc_without_interpolation.ad',
+            :simple_name => 'asciidoc_without_interpolation',
+            :syntax => :asciidoc,
+            :extension => '.html',
+            :matcher => verify_no_interpolation,
+            :site_overrides => { :interpolate => true }
         }
     ]
 

--- a/spec/test-data/handlers/asciidoc_with_interpolation.ad
+++ b/spec/test-data/handlers/asciidoc_with_interpolation.ad
@@ -1,0 +1,4 @@
+= Title
+:page-interpolate: true
+
+#{site.encoding}

--- a/spec/test-data/handlers/asciidoc_without_interpolation.ad
+++ b/spec/test-data/handlers/asciidoc_without_interpolation.ad
@@ -1,0 +1,3 @@
+= Title
+
+#{site.encoding}


### PR DESCRIPTION
- this patch also synchronizes AsciiDoc-based and YAML-based front-matter
