### PR TITLE
resolves #366 enhance Rakefile to properly handle release

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,42 +1,100 @@
 require 'rubygems'
+require 'date'
 require 'bundler/setup'
 require 'rspec/core/rake_task'
-require 'awestruct/version'
 
-GEMFILE = "awestruct-#{Awestruct::VERSION}.gem" 
+def gem_name
+  @gem_name ||= Dir['*.gemspec'].first.split('.').first
+end
+
+def gem_version
+  line = File.read("lib/#{gem_name}/version.rb")[/^\s*VERSION\s*=\s*.*/]
+  line.match(/.*VERSION\s*=\s*['"](.*)['"]/)[1]
+end
+
+def date
+  Date.today.to_s
+end
+
+def gemspec_file
+  "#{gem_name}.gemspec"
+end
+
+def gem_file
+  "#{gem_name}-#{gem_version}.gem"
+end
+
+def version_tag
+  "v#{gem_version}"
+end
+
+def replace_header(head, header_name)
+  head.sub!(/(\.#{header_name}\s*= ').*'/) { "#{$1}#{send(header_name)}'"}
+end
 
 task :default => :build
 
 if !defined?(RSpec)
-  puts "spec targets require RSpec"
+  puts 'spec targets require RSpec'
 else
-  desc "Run all examples"
+  desc 'Run all specs'
   RSpec::Core::RakeTask.new(:spec) do |t|
     t.pattern = 'spec/**/*_spec.rb'
     t.rspec_opts = ['-cfs']
   end
 end
 
-desc "Run all tests and build the gem"
-task :build => :spec do
-  system "gem build awestruct.gemspec"
+desc "Run all specs and build #{gem_file} into the pkg directory"
+task :build => [:spec, :gemspec] do
+  sh "gem build #{gemspec_file}"
+  sh 'mkdir -p pkg'
+  sh "mv #{gem_file} pkg"
+end
+
+desc "Build #{gem_file} and install it locally"
+task :install => :build do
+  sh "gem install -l -f pkg/#{gem_file}"
+end
+
+desc "Update #{gemspec_file}"
+task :gemspec do
+  spec = File.read(gemspec_file)
+
+  # replace name version and date
+  replace_header(spec, :gem_name)
+  replace_header(spec, :date)
+
+  File.open(gemspec_file, 'w') { |io| io.write spec }
+  puts "Updated #{gemspec_file}"
+end
+
+desc "Create tag #{version_tag} and push repository to origin"
+task :tag do
+  unless `git branch` =~ / master$/
+    puts 'You must be on the master branch to release!'
+    exit!
+  end
+  if version_tag.end_with?('.dev')
+    puts 'You cannot tag and release a dev version!'
+    exit!
+  end
+
+  if `git tag`.split(/\n/).include?(version_tag)
+    puts "Tag #{version_tag} has already been created."
+  else
+    sh "git commit --allow-empty -a -m 'Release #{gem_version}'"
+    sh 'git push origin master'
+    sh "git tag #{version_tag}"
+    sh "git push origin #{version_tag}"
+  end
 end
  
-desc "Release the gem to rubygems"
+desc "Build #{gem_file}, create and push tag #{version_tag} and publish gem to RubyGems.org"
 task :release => [ :build, :tag ] do
-  system "gem push #{GEMFILE}"
+  sh "gem push pkg/#{gem_file}"
 end
 
-desc "Build and install the gem locally"
-task :install => :build do
-  system "gem install -l -f #{GEMFILE}"
-end
-
-task :tag do
-  system "git tag #{Awestruct::VERSION}"
-end
-
-desc "Run `spectator` to monitor changes and execute specs in TDD fashion"
+desc 'Run `spectator` to monitor changes and execute specs in TDD fashion'
 task :tdd do
-  system "spectator"
+  sh 'spectator'
 end

--- a/awestruct.gemspec
+++ b/awestruct.gemspec
@@ -1,39 +1,47 @@
-require File.expand_path("../lib/awestruct/version", __FILE__)
+$:.push File.expand_path('../lib', __FILE__)
+require 'awestruct/version'
 
 spec = Gem::Specification.new do |s|
-    s.platform       =   Gem::Platform::RUBY
-    s.name           =   "awestruct"
-    s.version        =   Awestruct::VERSION
-    s.author         =   "Bob McWhirter and other contributors"
-    s.email          =   "bob@mcwhirter.org"
-    s.summary        =   "Static site-baking utility"
-    s.description    =   "Awestruct is a framework for creating static HTML sites."
-    s.homepage       =   "http://awestruct.org"
-    s.license        =   "MIT"
-    s.files          =   [
-      Dir['lib/**/**'],
-#      Dir['spec/**/**'],
-      Dir['man/*.1'],
-    ].flatten
-    s.test_files     = Dir['spec/**/**'].flatten
-    s.executables    = 'awestruct'
-    s.require_paths  = [ 'lib' ]
-    s.has_rdoc       =   true
+  s.name          = 'awestruct'
+  s.version       = Awestruct::VERSION
+  s.date          = '2013-09-14'
 
-    s.requirements  << "Any markup languages you are using and its dependencies" 
-    s.requirements  << "Haml and markdown filters are touchy things. Rdiscount works well if you're running on mri. JRuby should be using haml 4.0.0+ with kramdown"
+  s.authors       = ['Bob McWhirter', 'Jason Porter', 'Lance Ball', 'Dan Allen', 'Torsten Curdt', 'other contributors']
+  s.email         = ['bob@mcwhirter.org', 'lightguard.jp@gmail.com', 'lball@redhat.com', 'dan.j.allen@gmail.com', 'tcurdt@vafer.org']
+  s.homepage      = 'http://awestruct.org'
+  s.summary       = 'Static site baking and publishing tool'
+  s.description   = 'Awestruct is a static site baking and publishing tool. It supports an extensive list of both templating and markup languages via Tilt (Haml, Slim, AsciiDoc, Markdown, Sass via Compass, etc), provides mobile-first layout and styling via Bootstrap or Foundation, offers a variety of deployment options (rsync, git, S3), handles site optimizations (minification, compression, cache busting), includes built-in extensions such as blog post management and is highly extensible.'
 
-    s.add_dependency 'haml', '~> 4.0.1'
-    s.add_dependency 'nokogiri', '1.5.10'
-    s.add_dependency 'tilt', '>= 1.3.6'
-    s.add_dependency 'compass', '>= 0.12.1'
-    s.add_dependency 'compass-960-plugin', '~> 0.10.4'
-    s.add_dependency 'bootstrap-sass', '>= 2.3.1.0'
-    s.add_dependency 'zurb-foundation', '>= 4.0.9'
-    s.add_dependency 'rest-client', '>= 1.6.7'
-    s.add_dependency 'ruby-s3cmd', '~> 0.1.5'
+  s.rubyforge_project = s.name
 
-    s.add_dependency 'listen', '>= 0.7.3'
-    s.add_dependency 'rack', '~> 1.5.2'
+  s.license       = 'MIT'
+
+  s.platform      = Gem::Platform::RUBY
+
+  s.has_rdoc      = true
+  s.rdoc_options  = ['--charset=UTF-8']
+  s.extra_rdoc_files = 'README.md'
+
+  s.files         = `git ls-files -z -- {lib,man,spec}/* {README,LICENSE}* *{.gemspec,file}`.split("\0")
+  s.test_files    = s.files.select { |path| path =~ /^spec\/.*_spec\.rb/ }
+  s.executables   = `git ls-files -z -- bin/*`.split("\0").map {|f| File.basename f }
+  s.require_paths = ['lib']
+
+  s.requirements    = <<-EOS
+Any markup languages you are using and its dependencies.
+Haml and Markdown filters are touchy things. Redcarpet or Rdiscount work well if you're running on MRI. JRuby should be using haml 4.0.0+ with Kramdown.'
+  EOS
+
+  s.add_dependency 'haml', '~> 4.0.1'
+  s.add_dependency 'nokogiri', '1.5.10'
+  s.add_dependency 'tilt', '>= 1.3.6'
+  s.add_dependency 'compass', '>= 0.12.1'
+  s.add_dependency 'compass-960-plugin', '~> 0.10.4'
+  s.add_dependency 'bootstrap-sass', '>= 2.3.1.0'
+  s.add_dependency 'zurb-foundation', '>= 4.0.9'
+  s.add_dependency 'rest-client', '>= 1.6.7'
+  s.add_dependency 'ruby-s3cmd', '~> 0.1.5'
+
+  s.add_dependency 'listen', '>= 0.7.3'
+  s.add_dependency 'rack', '~> 1.5.2'
 end
-

--- a/lib/awestruct/version.rb
+++ b/lib/awestruct/version.rb
@@ -1,4 +1,3 @@
-
 module Awestruct
-  VERSION='0.5.4.rc'
+  VERSION = '0.5.4.dev'
 end


### PR DESCRIPTION
You can now release the gem using:

 $ rake release

It will remind you to update the version if it contains ".dev".
- updates the date in the gemspec
- creates the tag in git using pattern v%version%
- prevents release if version contains .dev
- pushes the repo to origin/master
- builds and pushes the package to rubygems.org
- updated the description of project
- added missing authors
- use git ls-tree to create package file lists
