### PR TITLE
Update auto mode to use Listen => 2.0.0 API

### DIFF
--- a/awestruct.gemspec
+++ b/awestruct.gemspec
@@ -42,6 +42,6 @@ Haml and Markdown filters are touchy things. Redcarpet or Rdiscount work well if
   s.add_dependency 'rest-client', '>= 1.6.7'
   s.add_dependency 'ruby-s3cmd', '~> 0.1.5'
 
-  s.add_dependency 'listen', '>= 0.7.3'
+  s.add_dependency 'listen', '>= 2.0.0'
   s.add_dependency 'rack', '~> 1.5.2'
 end

--- a/lib/awestruct/cli/auto.rb
+++ b/lib/awestruct/cli/auto.rb
@@ -16,11 +16,7 @@ module Awestruct
         current_path = nil
 
         force_polling = ( RUBY_PLATFORM =~ /mingw/ ? true : false )
-        listener = Listen.to( @config.dir, :relative_paths=>true, :latency=>0.5, :force_polling=>force_polling )
-        listener.ignore( %r(\.awestruct) )
-        listener.ignore( %r(^#{File.basename( @config.tmp_dir )}) )
-        listener.ignore( %r(^#{File.basename( @config.output_dir )}) )
-        listener.change do |modified, added, removed|
+        listener = Listen.to( @config.dir, :relative_paths=>true, :latency=>0.5, :force_polling=>force_polling ) do |modified, added, removed|
           modified.each do |path|
             engine = ::Awestruct::Engine.instance
             unless ( path =~ %r(#{File.basename( engine.config.output_dir) }) || path =~ /.awestruct/ )
@@ -49,7 +45,11 @@ module Awestruct
             end
           end
         end
-        listener.start(false)
+        listener.ignore( %r(\.awestruct) )
+        listener.ignore( %r(^#{File.basename( @config.tmp_dir )}) )
+        listener.ignore( %r(^#{File.basename( @config.output_dir )}) )
+        listener.start
+        sleep
       end
 
     end


### PR DESCRIPTION
Listen API has changed from the use of listen.change &block
to Listen.to() &block.
