### PR TITLE
Add any included partial (perhaps naively) to the site.partials

### DIFF
--- a/lib/awestruct/engine.rb
+++ b/lib/awestruct/engine.rb
@@ -327,6 +327,12 @@ module Awestruct
       full_path = File.join( '', path )
       page = site.pages.find{ |p| p.relative_source_path.to_s == full_path } ||
              site.layouts.find{ |p| p.relative_source_path.to_s == full_path }
+      #return if page.nil?
+
+      if ( page.nil? ) 
+        page = (site.partials||[]).find{ |p| p.relative_source_path.to_s == full_path }
+      end
+
       return if page.nil?
 
       if !page.output_path.nil?

--- a/lib/awestruct/extensions/partial.rb
+++ b/lib/awestruct/extensions/partial.rb
@@ -18,6 +18,10 @@ module Awestruct
           page.send( "#{k}=", v )
         end if params
 
+        Awestruct::Dependencies.top_page.site.partials ||= []
+        Awestruct::Dependencies.top_page.site.partials << page
+        Awestruct::Dependencies.track_dependency( page )
+
         page.content
       end
 


### PR DESCRIPTION
array (creating if necessary).

When the file-watcher notices a change, also search the partials.

And then re-generate dependents.
