### PR TITLE
support page specific exclude in sitemap extension

### DIFF
--- a/lib/awestruct/extensions/sitemap.rb
+++ b/lib/awestruct/extensions/sitemap.rb
@@ -83,10 +83,10 @@ module Awestruct
       end
 
       def valid_sitemap_entry( page )
-        if page.sitemap_exclude
+        if @excluded_files.member?(page.output_path) || @excluded_extensions.member?(page.output_extension) || page.sitemap_exclude
           false
         else
-          !@excluded_files.member?(page.output_path) && !@excluded_extensions.member?(page.output_extension)
+          true
         end
       end
 


### PR DESCRIPTION
allows the user to put `sitemap_exclude: true` in the page front matter and have it excluded. I will add to the sitemap docs @ the website once merged.
