### PR TITLE
A configuration based redirect page creation extension

### DIFF
--- a/lib/awestruct/extensions/redirect_creator.rb
+++ b/lib/awestruct/extensions/redirect_creator.rb
@@ -1,0 +1,105 @@
+# Awestruct extension creating html pages with redirect directives.
+#
+# Configuration via _config/redirects.yml or by passing a list of yaml files in the pipeline constructor,
+# e.g Awestruct::Extensions::RedirectCreator.new "foo", "bar"
+#
+# The extension also needs a template file containing the HTML for the redirect page. The path to the 
+# template can be configured in site.yml using the property 'redirect_creator_template'. If the property
+# is not set 'redirects.template' in _config is assumed. 
+#
+# %{url} should be used within the template to insert the redirect target.
+require 'awestruct/handlers/base_handler'
+
+module Awestruct
+  module Extensions
+    class RedirectCreator
+      Default_Redirect_Config = "redirects"
+
+      def initialize(*args)
+        @redirect_configs = Array.new
+        @redirect_configs.push(*args)
+        if @redirect_configs.index(Default_Redirect_Config) == nil
+          @redirect_configs.push(Default_Redirect_Config)
+        end
+      end
+
+      def execute(site)
+        @redirect_configs.each { |config|
+          if !site[config].nil?
+            site[config].each do |requested_url, target_url|
+              redirect_page = Page.new(site, Handlers::RedirectCreationHandler.new( site, requested_url, target_url ))
+              # make sure indexifier is ignoring redirect pages
+              redirect_page.inhibit_indexifier = true
+              site.pages << redirect_page
+            end
+          else
+            abort("Redirect config _config/#{config}.yml does not exist")
+          end
+
+        }
+      end
+    end
+  end
+
+  module Handlers
+    class RedirectCreationHandler < BaseHandler
+
+      Template_Config_Property = "redirect_creator_template"
+      Default_Redirect_Template = "redirects.template"
+      def initialize(site, requested_url, target_url)
+        super( site )
+        @requested_url = requested_url
+        @target_url = target_url
+        @creation_time = Time.new
+        template_file = site[Template_Config_Property]
+        if template_file.nil?
+          template_file = File.join(File.dirname(__FILE__), "..", "_config", Default_Redirect_Template)
+        end
+        @template = load_template template_file
+      end
+
+      def simple_name
+        File.basename( @requested_url, ".*" )
+      end
+
+      def output_filename
+        simple_name + output_extension
+      end
+
+      def output_extension
+        '.html'
+      end
+
+      def output_path
+        if( File.extname( @requested_url ).empty?)
+          File.join( File.dirname(@requested_url), simple_name, "index.html" )
+        else
+          File.join( File.dirname(@requested_url), output_filename )
+        end
+      end
+
+      def content_syntax
+        :text
+      end
+
+      def input_mtime(page)
+        @creation_time
+      end
+
+      def rendered_content(context, with_layouts=true)
+        @template
+      end
+
+      private
+      def load_template(template_file)
+        if !File.exist?(template_file)
+          abort("RedirectCreator is configured in pipeline, but redirect template (#{template_file}) does not exist")
+        end
+        file = File.open(template_file, "rb")
+        content = file.read
+        file.close
+        content % {url: @target_url}
+      end
+    end
+  end
+end

--- a/spec/redirect_creator_spec.rb
+++ b/spec/redirect_creator_spec.rb
@@ -1,0 +1,56 @@
+require 'awestruct/page'
+require 'awestruct/extensions/redirect_creator'
+require 'awestruct/logger'
+
+# create a global logget to avoid errors when executing internal classes using the logger
+$LOG = Logger.new(Awestruct::AwestructLoggerMultiIO.new)
+$LOG.level = Logger::DEBUG 
+$LOG.formatter = Awestruct::AwestructLogFormatter.new
+
+describe Awestruct::Extensions::RedirectCreator do
+
+  it "Without a redirect.yml config the extension should exit" do
+    site = Awestruct::AStruct.new :encoding=>false, :base_url=>'http://example.org'
+    redirect_creator = Awestruct::Extensions::RedirectCreator.new     
+    lambda { redirect_creator.execute(site) }.should raise_error(SystemExit, "Redirect config _config/redirects.yml does not exist")
+  end
+
+  it "Without a template file the extension should exit" do
+    site = Awestruct::AStruct.new :encoding=>false, :base_url=>'http://example.org'
+
+    redirects = { "foo" => "http://bar.com" }
+    site["redirects"] = redirects
+
+    redirect_creator = Awestruct::Extensions::RedirectCreator.new     
+    lambda { redirect_creator.execute(site) }.should raise_error(SystemExit, /RedirectCreator is configured in pipeline, but redirect template/)
+  end
+
+  it "A redirect page should be created" do
+    # create a test site
+    site = Awestruct::AStruct.new :encoding=>false, :base_url=>'http://example.org'
+    site.pages = []
+    site.config = {:track_dependencies => false}
+
+    # add the redirect config programatically 
+    redirects = { "foo" => "http://bar.com" }
+    site["redirects"] = redirects
+    site["redirect_creator_template"] = File.join(File.dirname(__FILE__), "test-data", "redirects.template") 
+
+    # create the extension under test  
+    redirect_creator = Awestruct::Extensions::RedirectCreator.new     
+     
+    # verify a age gets created
+    expect(site.pages.size).to be == 0  
+    redirect_creator.execute(site)
+    expect(site.pages.size).to be == 1 
+
+    # verify the page has the right path
+    created_page = site.pages[0]
+    expect(created_page.output_filename).to match("foo.html")
+
+    # verifiy the page contains the redirect target
+    context = Awestruct::Context.new ({:page => created_page, :site => site}) 
+    expect(created_page.rendered_content(context)).to match("http://bar.com")
+  end
+
+end

--- a/spec/test-data/redirects.template
+++ b/spec/test-data/redirects.template
@@ -1,0 +1,11 @@
+<!DOCTYPE HTML>
+
+<meta charset="UTF-8">
+<meta http-equiv="refresh" content="5; url=%{url}">
+
+<script>
+window.location.href = "%{url}"
+</script>
+
+<title>Page Redirection</title>
+Looks like you used an old link. We will teleport you to the <a href='%{url}'>right place</a> in a second. }


### PR DESCRIPTION
An extension which does the same as _redirect.handler_, except that it takes the list of redirect pages from a yaml configuration file. This makes it easier to create a whole list of redirect pages and avoids to have all <page>.redirect files in the source code.
