### PR TITLE
Issue #399 - Use new analytics.js script from Google Universal Analytics

### DIFF
--- a/lib/awestruct/extensions/google_universal_analytics.rb
+++ b/lib/awestruct/extensions/google_universal_analytics.rb
@@ -1,0 +1,22 @@
+module Awestruct
+  module Extensions
+    module GoogleUniversalAnalytics
+
+      def google_analytics()
+        html = ''
+        html += %Q(<script>\n)
+        html += %Q( (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){\n
+                    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),\n
+                    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)\n
+                    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');\n )
+        html += %Q(\n)
+        html += %Q(ga('create', '#{site.google_analytics}', 'auto');\n)
+        html += %Q(ga('send', 'pageview');\n)
+        html += %Q(\n)
+        html += %Q(</script>\n)
+        html
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
I took the option to create a new helper (which would need to be documented but the website and the released are still separated).
This is a safe approach as Google does the migration in phases and the old code is supposed to work for a while.
We could decide to replace the old Helper and reimplement it. I am fine with it. Opinions?
