### PR TITLE
Update compass version

### DIFF
--- a/awestruct.gemspec
+++ b/awestruct.gemspec
@@ -36,7 +36,7 @@ Haml and Markdown filters are touchy things. Redcarpet or Rdiscount work well if
   s.add_dependency 'asciidoctor' # we're pretty good about backwards compat
   s.add_dependency 'nokogiri', '~> 1.5.10'
   s.add_dependency 'tilt', '~> 2.0.1'
-  s.add_dependency 'compass', '~> 0.12.4'
+  s.add_dependency 'compass', '~> 1.0.1'
   s.add_dependency 'compass-960-plugin', '~> 0.10.4'
   s.add_dependency 'bootstrap-sass', '~> 3.1.1.0'
   s.add_dependency 'zurb-foundation', '~> 4.3.2'


### PR DESCRIPTION
Required for foundation 5 to run properly.
