### PR TITLE
Add regenerate on Page HTTP Request access

### DIFF
--- a/lib/awestruct/cli/generate.rb
+++ b/lib/awestruct/cli/generate.rb
@@ -6,11 +6,12 @@ module Awestruct
   module CLI
     class Generate
 
-      def initialize(config, profile=nil, base_url=nil, default_base_url=Options::DEFAULT_BASE_URL, force=false)
+      def initialize(config, profile=nil, base_url=nil, default_base_url=Options::DEFAULT_BASE_URL, force=false, generate=true)
         @profile          = profile
         @base_url         = base_url
         @default_base_url = default_base_url
         @force            = force
+        @generate         = generate
         @engine           = Awestruct::Engine.new( config )
       end
 
@@ -18,7 +19,7 @@ module Awestruct
         begin
           base_url = @base_url || @default_base_url
           $LOG.info "Generating site: #{base_url}" if $LOG.info?
-          @engine.run( @profile, @base_url, @default_base_url, @force )
+          @engine.run( @profile, @base_url, @default_base_url, @force, @generate )
         rescue =>e
           ExceptionHelper.log_building_error e, ''
           return false

--- a/lib/awestruct/cli/invoker.rb
+++ b/lib/awestruct/cli/invoker.rb
@@ -122,7 +122,7 @@ module Awestruct
 
       def invoke_generate()
         base_url = profile['base_url'] || options.base_url
-        @success = Awestruct::CLI::Generate.new( config, options.profile, base_url, Options::DEFAULT_BASE_URL, options.force ).run
+        @success = Awestruct::CLI::Generate.new( config, options.profile, base_url, Options::DEFAULT_BASE_URL, options.force, !options.generate_on_access ).run
       end
 
       def invoke_deploy()
@@ -144,7 +144,7 @@ module Awestruct
       end
 
       def invoke_server()
-        run_in_thread( Awestruct::CLI::Server.new( options.output_dir, options.bind_addr, options.port ) )
+        run_in_thread( Awestruct::CLI::Server.new( options.output_dir, options.bind_addr, options.port, options.generate_on_access ) )
       end
 
 

--- a/lib/awestruct/cli/options.rb
+++ b/lib/awestruct/cli/options.rb
@@ -16,6 +16,7 @@ module Awestruct
       DEFAULT_BIND_ADDR = '0.0.0.0'
       DEFAULT_PORT = 4242
       DEFAULT_BASE_URL = %(http://#{LOCAL_HOSTS[DEFAULT_BIND_ADDR] || DEFAULT_BIND_ADDR}:#{DEFAULT_PORT})
+      DEFAULT_GENERATE_ON_ACCESS = false
 
       attr_accessor :generate
       attr_accessor :server
@@ -36,6 +37,7 @@ module Awestruct
       attr_accessor :output_dir
       attr_accessor :livereload
       attr_accessor :debug
+      attr_accessor :generate_on_access
 
       def initialize()
         @generate   = nil
@@ -56,6 +58,7 @@ module Awestruct
         @livereload = false
         @source_dir = Dir.pwd
         @output_dir = File.expand_path '_site'
+        @generate_on_access = DEFAULT_GENERATE_ON_ACCESS
       end
 
       def self.parse!(args)
@@ -92,12 +95,13 @@ module Awestruct
           opts.on( '-u', '--url URL', 'Set site.base_url' ) do |url|
             self.base_url = url
           end
-          opts.on( '-d', '--dev',     "Run site in development mode (--auto, --server, --port #{DEFAULT_PORT} and --profile development)" ) do |url|
+          opts.on( '-d', '--dev',     "Run site in development mode (--auto, --server, --port #{DEFAULT_PORT}, --profile development, --livereload and --generate_on_access)" ) do |url|
             self.server   = true
             self.auto     = true
             self.port     = DEFAULT_PORT
             self.profile  = 'development'
             self.livereload = true
+            self.generate_on_access = true
           end
           opts.on( '-a', '--auto', 'Auto-generate when changes are noticed' ) do |a|
             self.auto = a
@@ -105,6 +109,11 @@ module Awestruct
           end
           opts.on( '--[no-]livereload', 'Support for browser livereload' ) do |livereload|
             self.livereload = livereload
+            self.generate_on_access = true  if self.livereload
+          end
+
+          opts.on( '--[no-]generate-on-access', 'Support for calling generate on HTTP access' ) do |generate_on_access|
+            self.generate_on_access = generate_on_access
           end
 
           opts.on( '-P', '--profile PROFILE', 'Activate a configuration profile' ) do |profile|

--- a/lib/awestruct/cli/server.rb
+++ b/lib/awestruct/cli/server.rb
@@ -1,26 +1,39 @@
 require 'rack'
+require 'rack/builder'
 require 'rack/server'
 require 'awestruct/rack/app'
+require 'awestruct/rack/generate'
 
 module Awestruct
   module CLI
     class Server
       attr_reader :server
 
-      def initialize(path, bind_addr=Options::DEFAULT_BIND_ADDR, port=Options::DEFAULT_PORT)
+      def initialize(path, bind_addr=Options::DEFAULT_BIND_ADDR, port=Options::DEFAULT_PORT, generate_on_access=Options::DEFAULT_GENERATE_ON_ACCESS)
         @path      = path
         @bind_addr = bind_addr
         @port      = port
+        @generate_on_access = generate_on_access
       end
 
       def run
         url = %(http://#{Options::LOCAL_HOSTS[@bind_addr] || @bind_addr}:#{@port})
         msg = %(Starting preview server at #{url} (Press Ctrl-C to shutdown))
         puts %(#{'*' * msg.length}\n#{msg}\n#{'*' * msg.length}\n)
-        ::Rack::Server::start( :app => Awestruct::Rack::App.new( @path ),
-                              :Port => @port,
-                              :Host => @bind_addr
-                             )
+
+        path = @path
+        generate_on_access = @generate_on_access
+        app = ::Rack::Builder.new do
+          use Awestruct::Rack::GenerateOnAccess if generate_on_access
+          map "/" do
+            run Awestruct::Rack::App.new( path )
+          end
+        end
+
+          ::Rack::Server::start( :app => app,
+                                :Port => @port,
+                                :Host => @bind_addr
+                               )
       end 
     end
   end

--- a/lib/awestruct/rack/generate.rb
+++ b/lib/awestruct/rack/generate.rb
@@ -1,0 +1,45 @@
+
+module Awestruct
+  module Rack
+
+    class GenerateOnAccess
+      def initialize(app)
+        @app = app
+      end
+
+      def call(env)
+        engine = ::Awestruct::Engine.instance
+
+        generate = false
+
+        req_path = env['REQUEST_PATH']
+        path = req_path
+        path = req_path + "index.html" if req_path.end_with? '/'
+
+        page = engine.site.pages_by_output_path[path]
+        if page.nil? and !req_path.end_with? '/'
+          path = req_path + "/index.html"
+          page = engine.site.pages_by_output_path[path]
+        end
+
+        generate_path = nil
+
+        if !page.nil?
+          generate_path = File.join( engine.site.config.output_dir, page.output_path )
+
+          generate = true if page.stale_output? generate_path
+          generate = true if path.end_with? '.html'
+        end
+
+        if generate
+          puts "Regenerate #{page.source_path}"
+
+          engine.generate_page page, generate_path, true
+        end
+
+        @app.call(env)
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
Add support for triggering generation of output on
page access via WebServer instead of on page save.

The reverse lookup allow us to regenerate only the requested page
and not all the dependent pages or pages that use the given changed
layout.

Note: Only intended in development mode

Activate by enabling server but not auto:

awstruct -s -P development --generate-on-access


Thoughts?