### PR TITLE
Remove CSS framework version dependencies from Awestruct

### DIFF
--- a/awestruct.gemspec
+++ b/awestruct.gemspec
@@ -35,10 +35,6 @@ Haml and Markdown filters are touchy things. Redcarpet or Rdiscount work well if
   s.add_dependency 'haml', '~> 4.0.5'
   s.add_dependency 'asciidoctor' # we're pretty good about backwards compat
   s.add_dependency 'tilt', '~> 2.0.1'
-  s.add_dependency 'compass', '~> 1.0.1'
-  s.add_dependency 'compass-960-plugin', '~> 0.10.4'
-  s.add_dependency 'bootstrap-sass', '~> 3.2.0.2'
-  s.add_dependency 'zurb-foundation', '~> 4.3.2'
   s.add_dependency 'mime-types', '~> 2.1'
   s.add_dependency 'rest-client', '~> 1.7.2'
   s.add_dependency 'ruby-s3cmd', '~> 0.1.5'
@@ -50,4 +46,8 @@ Haml and Markdown filters are touchy things. Redcarpet or Rdiscount work well if
   s.add_dependency 'parallel', '> 1.1.1'
 
   s.add_development_dependency 'nokogiri', '~> 1.5.10'
+  s.add_development_dependency 'compass', '~> 1.0.1'
+  s.add_development_dependency 'compass-960-plugin', '~> 0.10.4'
+  s.add_development_dependency 'bootstrap-sass', '~> 3.2.0.2'
+  s.add_development_dependency 'zurb-foundation', '~> 4.3.2'
 end

--- a/lib/awestruct/cli/init.rb
+++ b/lib/awestruct/cli/init.rb
@@ -18,7 +18,6 @@ module Awestruct
         copy_file('_ext/pipeline.rb', Init.framework_path('base_pipeline.rb'))
         copy_file('.awestruct_ignore', Init.framework_path('base_awestruct_ignore'))
         copy_file('Rakefile', Init.framework_path('base_Rakefile'))
-        copy_file('Gemfile', Init.framework_path('base_Gemfile'))
         mkdir('stylesheets')
       }
 
@@ -31,6 +30,8 @@ module Awestruct
       def run()
         manifest = Manifest.new(BASE_MANIFEST)
         scaffold_name = @framework
+        manifest.template_file('Gemfile', Init.framework_path('base_Gemfile'), {:framework => @framework})
+
         lib = nil
         case @framework
           when 'compass'

--- a/lib/awestruct/frameworks/base_Gemfile
+++ b/lib/awestruct/frameworks/base_Gemfile
@@ -24,8 +24,19 @@
 
 source 'https://rubygems.org'                             # This tells Bundler where to look for gems
 
-gem 'awestruct', '~> 0.5.3'                               # Goes without saying
+gem 'awestruct', '>= <%= awestruct_version %>'                               # Goes without saying
 gem 'webrick', '~> 1.3.1'                                 # The rack webserver to use in dev mode
+
+gem 'compass', '<%= dependencies['compass'].requirement %>'
+<% if framework.eql? 'bootstrap' %>
+gem 'bootstrap-sass', '<%= dependencies['bootstrap-sass'].requirement %>'
+<% end %>
+<% if framework.eql? 'foundation' %>
+gem 'zurb-foundation', '<%= dependencies['zurb-foundation'].requirement %>'
+<% end %>
+<% if framework.eql? '960' %>
+gem 'compass-960-plugin', '<%= dependencies['compass-960-plugin'].requirement %>'
+<% end %>
 
 # FIXME
 # gem 'rake', '>= 0.9.2'                                  # Needed for the Rakefile to work


### PR DESCRIPTION
Move selection of CSS framework to Gemfile created during
initialization of a new site.

It should be up to each site to determine given version of e.g.
bootstrap.

Thoughts?