### PR TITLE
Adding new extension hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ spec/.sass-cache/*/*.scssc
 .rvmrc
 .sass-cache
 coverage
+_site

--- a/lib/awestruct/engine.rb
+++ b/lib/awestruct/engine.rb
@@ -247,14 +247,14 @@ module Awestruct
       pipeline_file = File.join( ext_dir, 'pipeline.rb' )
       if ( File.exists?( pipeline_file ) )
         p = eval(File.read( pipeline_file ), nil, pipeline_file, 1)
-        p.before_pipeline_extensions.each do |e|
-          pipeline.before_pipeline_extension( e )
+        p.before_all_extensions.each do |e|
+          pipeline.add_before_extension( e )
         end
         p.extensions.each do |e|
           pipeline.extension( e )
         end
-        p.after_pipeline_extensions.each do |e|
-          pipeline.after_pipeline_extension( e )
+        p.after_all_extensions.each do |e|
+          pipeline.add_after_extension( e )
         end
         p.helpers.each do |h|
           pipeline.helper( h )
@@ -263,7 +263,7 @@ module Awestruct
           pipeline.transformer( t )
         end
         p.after_generation_extensions.each do |e|
-          pipeline.after_generation_extension( e )
+          pipeline.add_after_generation_extension( e )
         end
       end
     end

--- a/lib/awestruct/extensions/pipeline.rb
+++ b/lib/awestruct/extensions/pipeline.rb
@@ -15,19 +15,19 @@ module Awestruct
     # declare their extensions, helpers, transformers, etc.
     class Pipeline
 
-      attr_reader :before_pipeline_extensions
+      attr_reader :before_all_extensions
       attr_reader :extensions
-      attr_reader :after_pipeline_extensions
+      attr_reader :after_all_extensions
       attr_reader :helpers
       attr_reader :transformers
       attr_reader :after_generation_extensions
 
       def initialize(&block)
-        @before_pipeline_extensions  = []
+        @before_all_extensions       = []
         @extensions                  = []
         @helpers                     = []
         @transformers                = []
-        @after_pipeline_extensions   = []
+        @after_all_extensions        = []
         @after_generation_extensions = []
         begin
           instance_eval(&block) if block
@@ -37,17 +37,21 @@ module Awestruct
       end
 
       def before_extensions(ext)
-        @before_pipeline_extensions << ext
+        @before_all_extensions << ext
       end
 
       def extension(ext)
-        @extensions << ext
+        @extensions << ext if ext.respond_to?(:execute)
         # TC: why? transformer and extension?
-        ext.transform(@transformers) if ext.respond_to?('transform')
+        ext.transform(@transformers) if ext.respond_to?(:transform)
+
+        @before_all_extensions << ext if ext.respond_to?(:before_extensions)
+        @after_all_extensions << ext if ext.respond_to?(:after_extensions)
+        @after_generation_extensions << ext if ext.respond_to?(:after_generation)
       end
 
       def after_extensions(ext)
-        @after_pipeline_extensions << ext
+        @after_all_extensions << ext
       end
 
       def helper(helper)

--- a/lib/awestruct/extensions/pipeline.rb
+++ b/lib/awestruct/extensions/pipeline.rb
@@ -11,23 +11,33 @@ end
 
 module Awestruct
   module Extensions
+    # Public. Extension declaration class, initialized by the end user to
+    # declare their extensions, helpers, transformers, etc.
     class Pipeline
 
-      attr_reader :before_extensions
+      attr_reader :before_pipeline_extensions
       attr_reader :extensions
-      attr_reader :after_extensions
+      attr_reader :after_pipeline_extensions
       attr_reader :helpers
       attr_reader :transformers
+      attr_reader :after_generation_extensions
 
       def initialize(&block)
-        @extensions   = []
-        @helpers      = []
-        @transformers = []
+        @before_pipeline_extensions  = []
+        @extensions                  = []
+        @helpers                     = []
+        @transformers                = []
+        @after_pipeline_extensions   = []
+        @after_generation_extensions = []
         begin
-          instance_eval &block if block
+          instance_eval(&block) if block
         rescue Exception => e
           abort("Failed to initialize pipeline: #{e}")
         end
+      end
+
+      def before_extensions(ext)
+        @before_pipeline_extensions << ext
       end
 
       def extension(ext)
@@ -36,12 +46,20 @@ module Awestruct
         ext.transform(@transformers) if ext.respond_to?('transform')
       end
 
+      def after_extensions(ext)
+        @after_pipeline_extensions << ext
+      end
+
       def helper(helper)
         @helpers << helper
       end
 
       def transformer(transformer)
         @transformers << transformer
+      end
+
+      def after_generation(ext)
+        @after_generation_extensions << ext
       end
 
       def execute(site)

--- a/lib/awestruct/pipeline.rb
+++ b/lib/awestruct/pipeline.rb
@@ -6,35 +6,35 @@ module Awestruct
   class Pipeline
 
     attr_reader :handler_chains
-    attr_reader :before_pipeline_extensions
+    attr_reader :before_all_extensions
     attr_reader :extensions
-    attr_reader :after_pipeline_extensions
+    attr_reader :after_all_extensions
     attr_reader :helpers
     attr_reader :transformers
     attr_reader :after_generation_extensions
 
     def initialize()
       @handler_chains = HandlerChains.new
-      @before_pipeline_extensions  = []
+      @before_all_extensions       = []
       @extensions                  = []
       @helpers                     = []
       @transformers                = []
-      @after_pipeline_extensions   = []
+      @after_all_extensions        = []
       @after_generation_extensions = []
     end
 
-    def before_pipeline_extension(e)
-      @before_pipeline_extensions << e
+    def add_before_extension(e)
+      @before_all_extensions << e
     end
 
     def extension(e)
       @extensions << e
       # TC: why? transformer and extension?
-      e.transform(@transformers) if e.respond_to?('transform')
+      e.transform(@transformers) if e.respond_to?(:transform)
     end
 
-    def after_pipeline_extension(e)
-      @after_pipeline_extensions << e
+    def add_after_extension(e)
+      @after_all_extensions << e
     end
 
     def helper(h)
@@ -45,7 +45,7 @@ module Awestruct
       @transformers << t
     end
 
-    def after_generation_extension(e)
+    def add_after_generation_extension(e)
       @after_generation_extensions << e
     end
 
@@ -54,7 +54,7 @@ module Awestruct
     end
 
     def execute_extensions(site, on_reload)
-      @before_pipeline_extensions.each do |e|
+      @before_all_extensions.each do |e|
         e.on_reload(site) if (on_reload && e.respond_to?(:on_reload))
         e.execute(site)
       end
@@ -64,7 +64,7 @@ module Awestruct
         e.execute(site)
       end
 
-      @after_pipeline_extensions.each do |e|
+      @after_all_extensions.each do |e|
         e.on_reload(site) if (on_reload && e.respond_to?(:on_reload))
         e.execute(site)
       end

--- a/lib/awestruct/pipeline.rb
+++ b/lib/awestruct/pipeline.rb
@@ -6,18 +6,35 @@ module Awestruct
   class Pipeline
 
     attr_reader :handler_chains
+    attr_reader :before_pipeline_extensions
+    attr_reader :extensions
+    attr_reader :after_pipeline_extensions
+    attr_reader :helpers
+    attr_reader :transformers
+    attr_reader :after_generation_extensions
 
     def initialize()
       @handler_chains = HandlerChains.new
-      @extensions     = []
-      @helpers        = []
-      @transformers   = []
+      @before_pipeline_extensions  = []
+      @extensions                  = []
+      @helpers                     = []
+      @transformers                = []
+      @after_pipeline_extensions   = []
+      @after_generation_extensions = []
+    end
+
+    def before_pipeline_extension(e)
+      @before_pipeline_extensions << e
     end
 
     def extension(e)
       @extensions << e
       # TC: why? transformer and extension?
       e.transform(@transformers) if e.respond_to?('transform')
+    end
+
+    def after_pipeline_extension(e)
+      @after_pipeline_extensions << e
     end
 
     def helper(h)
@@ -28,12 +45,27 @@ module Awestruct
       @transformers << t
     end
 
-    def execute(site)
-      execute_extensions(site)
+    def after_generation_extension(e)
+      @after_generation_extensions << e
     end
 
-    def execute_extensions(site)
+    def execute(site, on_reload = false)
+      execute_extensions(site, on_reload)
+    end
+
+    def execute_extensions(site, on_reload)
+      @before_pipeline_extensions.each do |e|
+        e.on_reload(site) if (on_reload && e.respond_to?(:on_reload))
+        e.execute(site)
+      end
+
       @extensions.each do |e|
+        e.on_reload(site) if (on_reload && e.respond_to?(:on_reload))
+        e.execute(site)
+      end
+
+      @after_pipeline_extensions.each do |e|
+        e.on_reload(site) if (on_reload && e.respond_to?(:on_reload))
         e.execute(site)
       end
     end
@@ -43,6 +75,12 @@ module Awestruct
         rendered = t.transform( site, page, rendered )
       end
       rendered
+    end
+
+    def execute_after_generation(site)
+      @after_generation_extensions.each do |e|
+        e.execute(site)
+      end
     end
 
     def mixin_helpers(context)

--- a/spec/awestruct/pipeline_spec.rb
+++ b/spec/awestruct/pipeline_spec.rb
@@ -1,15 +1,32 @@
-
-require 'awestruct/pipeline'
-
+require 'awestruct/engine'
+require 'awestruct/pipeline' 
 
 describe Awestruct::Pipeline do
-  before do
-    dir = Pathname.new( test_data_dir 'engine' )
+  before do 
+    dir = Pathname.new( test_data_dir 'pipeline' )
     opts = Awestruct::CLI::Options.new
     opts.source_dir = dir
 
-    @site = Hashery::OpenCascade[ { :encoding=>false, :dir=>dir, :config=>Awestruct::Config.new( opts ) } ]
-    Awestruct::Engine.new(@site.config)
+    @site = Hashery::OpenCascade[ { :encoding=>false, :dir=>dir, :config=>Awestruct::Config.new( opts ), :pages => [] } ]
+    @engine = Awestruct::Engine.new(@site.config)
+
+    log = StringIO.new
+    $LOG = Logger.new(log)
+    $LOG.level = Logger::DEBUG 
+
+    @engine.load_pipeline
+    @pipeline = @engine.pipeline
+  end
+
+  context "after pipeline is loaded" do 
+    specify "should have all specified extension points" do
+      expect(@pipeline.before_pipeline_extensions.size).to eql 1
+      expect(@pipeline.extensions.size).to eql 1
+      expect(@pipeline.after_pipeline_extensions.size).to eql 1
+      expect(@pipeline.helpers.size).to eql 1
+      expect(@pipeline.transformers.size).to eql 1
+      expect(@pipeline.after_generation_extensions.size).to eql 1
+    end
   end
 
   it "should provide a way to find a matching handler chain for a given path" do

--- a/spec/awestruct/pipeline_spec.rb
+++ b/spec/awestruct/pipeline_spec.rb
@@ -20,9 +20,9 @@ describe Awestruct::Pipeline do
 
   context "after pipeline is loaded" do 
     specify "should have all specified extension points" do
-      expect(@pipeline.before_pipeline_extensions.size).to eql 1
+      expect(@pipeline.before_all_extensions.size).to eql 1
       expect(@pipeline.extensions.size).to eql 1
-      expect(@pipeline.after_pipeline_extensions.size).to eql 1
+      expect(@pipeline.after_all_extensions.size).to eql 1
       expect(@pipeline.helpers.size).to eql 1
       expect(@pipeline.transformers.size).to eql 1
       expect(@pipeline.after_generation_extensions.size).to eql 1

--- a/spec/support/test-data/pipeline/_ext/extensions.rb
+++ b/spec/support/test-data/pipeline/_ext/extensions.rb
@@ -1,0 +1,26 @@
+module Awestruct
+  module Test
+    module Extensions
+      class TestBeforeExtension
+        def execute site
+        end
+      end
+
+      class TestAfterExtension
+        def execute site
+        end
+      end
+
+      class TestAfterGenerationExtension
+        def execute site
+        end
+      end
+
+      class LinkTransformer
+        def transform site, page, content
+        end
+      end
+    end
+  end
+end
+

--- a/spec/support/test-data/pipeline/_ext/extensions.rb
+++ b/spec/support/test-data/pipeline/_ext/extensions.rb
@@ -2,7 +2,7 @@ module Awestruct
   module Test
     module Extensions
       class TestBeforeExtension
-        def execute site
+        def before_extensions site
         end
       end
 

--- a/spec/support/test-data/pipeline/_ext/pipeline.rb
+++ b/spec/support/test-data/pipeline/_ext/pipeline.rb
@@ -1,4 +1,5 @@
 require 'support/test-data/pipeline/_ext/extensions'
+require 'awestruct/extensions/pipeline'
 
 Awestruct::Extensions::Pipeline.new do
   before_extensions Awestruct::Test::Extensions::TestBeforeExtension.new

--- a/spec/support/test-data/pipeline/_ext/pipeline.rb
+++ b/spec/support/test-data/pipeline/_ext/pipeline.rb
@@ -2,7 +2,7 @@ require 'support/test-data/pipeline/_ext/extensions'
 require 'awestruct/extensions/pipeline'
 
 Awestruct::Extensions::Pipeline.new do
-  before_extensions Awestruct::Test::Extensions::TestBeforeExtension.new
+  extension Awestruct::Test::Extensions::TestBeforeExtension.new
   extension Awestruct::Extensions::Indexifier.new
   after_extensions Awestruct::Test::Extensions::TestAfterExtension.new
   helper Awestruct::Extensions::Relative

--- a/spec/support/test-data/pipeline/_ext/pipeline.rb
+++ b/spec/support/test-data/pipeline/_ext/pipeline.rb
@@ -1,0 +1,11 @@
+require 'support/test-data/pipeline/_ext/extensions'
+
+Awestruct::Extensions::Pipeline.new do
+  before_extensions Awestruct::Test::Extensions::TestBeforeExtension.new
+  extension Awestruct::Extensions::Indexifier.new
+  after_extensions Awestruct::Test::Extensions::TestAfterExtension.new
+  helper Awestruct::Extensions::Relative
+  transformer Awestruct::Test::Extensions::LinkTransformer.new
+  after_generation Awestruct::Test::Extensions::TestAfterGenerationExtension.new
+end
+


### PR DESCRIPTION
There are three new extension hooks in place now:

* before_extensions
+ All extensions added via this method, following the same extension rules,
will be run before any other extensions loaded with `extension`.
* after_extensions
+ All extensions added via this method, following the same extension rules,
will be run after any other extensions loaded with `extension`.
* after_generation
+ All extensions added via this method, following the same extension rules,
will be run after the page generation is completed. This will only run on the 
first generation, not on reloads.

Extensions will now be notified if they are being reloaded. To be notified of
this an extension must have an `on_reload(site)` method, which will be called
if there is a change. An extension is then free to re-run an initialization
logic, clean-up the site variable, or create new state needed for a re-run of
the `execute(site)` method.