### PR TITLE
Fixes #456 adding in '/' for directories on relative lookups

### DIFF
--- a/lib/awestruct/extensions/relative.rb
+++ b/lib/awestruct/extensions/relative.rb
@@ -11,7 +11,9 @@ module Awestruct
           if href.start_with?("http://") || href.start_with?("https://")
             result = href
           else
-            result = Pathname.new(href).relative_path_from(Pathname.new(File.dirname(p.output_path))).to_s
+            pathname = Pathname.new(href).relative_path_from(Pathname.new(File.dirname(p.output_path)))
+            result = pathname.to_s
+            result << '/' if pathname.extname.empty?
           end
           result
         rescue Exception => e

--- a/lib/awestruct/extensions/tagger.rb
+++ b/lib/awestruct/extensions/tagger.rb
@@ -20,7 +20,11 @@ module Awestruct
       module TagLinker
         def tag_links(delimiter = ', ', style_class = nil)
           class_attr = (style_class ? ' class="' + style_class + '"' : '')
-          tags.map{|tag| %Q{<a#{class_attr} href="#{tag.primary_page.url}">#{tag}</a>}}.join(delimiter)
+          tags.map do |tag|
+            url = tag.primary_page.url
+            url << '/' unless (url.include?('.htm') || url.end_with?('/'))
+            %Q{<a#{class_attr} href="#{url}">#{tag}</a>}
+          end.join(delimiter)
         end
       end
 

--- a/spec/awestruct/extensions/relative_spec.rb
+++ b/spec/awestruct/extensions/relative_spec.rb
@@ -1,0 +1,22 @@
+require 'awestruct/extensions/relative'
+require 'ostruct'
+
+describe Awestruct::Extensions::Relative do
+  let(:dummy_class) { Class.new { extend Awestruct::Extensions::Relative } }
+
+  context 'with file extension' do
+    let (:page) { OpenStruct.new(:output_path => 'site/base/path/file.html') }
+
+    it "should should not  have '/' at the end if there is a file extension" do
+      expect(dummy_class.relative('site/base/path/another_file.html', page)).to eql 'another_file.html'
+    end
+  end
+
+  context 'without file extension' do
+    let (:page) { OpenStruct.new(:output_path => 'site/base/path/file.html') }
+
+    it "should should not  have '/' at the end if there is a file extension" do
+      expect(dummy_class.relative('site/base/path/some_directory', page)).to eql 'some_directory/'
+    end
+  end
+end


### PR DESCRIPTION
If `relative` is called and the href given is a directory we need to append
'/' to avoid an extra redirect.