### PR TITLE
AsciidoctorHandler should inherit from the TiltHandler

### DIFF
--- a/lib/awestruct/handlers/asciidoctor_handler.rb
+++ b/lib/awestruct/handlers/asciidoctor_handler.rb
@@ -23,7 +23,7 @@ module Awestruct
       end
     end
 
-    class AsciidoctorHandler < BaseTiltHandler
+    class AsciidoctorHandler < TiltHandler
 
       CHAIN = Awestruct::HandlerChain.new( Awestruct::Handlers::AsciidoctorTiltMatcher.new(),
         Awestruct::Handlers::FileHandler,


### PR DESCRIPTION
This way the appropriate set up of Tilt templates will occur when we're using the AsciidoctorHandler

Fixes #478