### PR TITLE
Resolves #288, Store Asciidoctor::Document object in page context

### DIFF
--- a/lib/awestruct/handlers/template/asciidoc.rb
+++ b/lib/awestruct/handlers/template/asciidoc.rb
@@ -19,7 +19,7 @@ module Awestruct
       end
 
       def evaluate(scope, locals, &block)
-        @output ||= (scope.document = ::Asciidoctor.load(data, options, &block)).convert
+        @output ||= (scope.document = ::Asciidoctor.load(data, options)).convert
       end
 
       def allows_script?

--- a/lib/awestruct/handlers/template/asciidoc.rb
+++ b/lib/awestruct/handlers/template/asciidoc.rb
@@ -19,7 +19,7 @@ module Awestruct
       end
 
       def evaluate(scope, locals, &block)
-        @output ||= ::Asciidoctor.render(data, options, &block)
+        @output ||= (scope.document = ::Asciidoctor.load(data, options, &block)).convert
       end
 
       def allows_script?


### PR DESCRIPTION
Store `Asciidoctor::Document` object in page context

Resolves #288