### PR TITLE
Invoke the right #log_backtrace method upon partial errors

### DIFF
--- a/lib/awestruct/extensions/partial.rb
+++ b/lib/awestruct/extensions/partial.rb
@@ -37,7 +37,7 @@ module Awestruct
         begin
           page.content
         rescue Exception => e
-          ExceptionHelper.log_error "Error occurred while rendering partial #{filename} contained in #{self[:page].source_path}"
+          ExceptionHelper.log_message "Error occurred while rendering partial #{filename} contained in #{self[:page].source_path}"
           ExceptionHelper.log_backtrace e 
         end 
       end

--- a/lib/awestruct/extensions/partial.rb
+++ b/lib/awestruct/extensions/partial.rb
@@ -38,7 +38,7 @@ module Awestruct
           page.content
         rescue Exception => e
           ExceptionHelper.log_error "Error occurred while rendering partial #{filename} contained in #{self[:page].source_path}"
-          ExceptionHelper.backtrace e 
+          ExceptionHelper.log_backtrace e 
         end 
       end
     end


### PR DESCRIPTION
This helps ensure that partial rendering errors actually get logged properly