### PR TITLE
Fix broken travis build

### DIFF
--- a/awestruct.gemspec
+++ b/awestruct.gemspec
@@ -39,7 +39,7 @@ Compass and sass are no longer hard dependencies. You'll need too add them on yo
   s.add_dependency 'tilt', '~> 2.0', '>= 2.0.1'
   s.add_dependency 'mime-types', '~> 3.0'
   s.add_dependency 'rest-client', '~> 2.0'
-  s.add_dependency 'listen', '>= 2.7.1', '<= 4.0'
+  s.add_dependency 'listen', '>= 2.7.1', '<= 3.0.8'
   s.add_dependency 'rack', '~> 1.5', '>= 1.5.2'
   s.add_dependency 'git', '~> 1.2', '>= 1.2.6'
   s.add_dependency 'guard', '~> 2.0', '>= 2.13.0'

--- a/spec/awestruct/engine_spec.rb
+++ b/spec/awestruct/engine_spec.rb
@@ -117,7 +117,7 @@ describe Awestruct::Engine do
 
     expect( Compass.configuration.line_comments ).to eq false
     expect( Compass.configuration.output_style ).to eq :compressed
-    expect( Compass.configuration.http_path ).to eq "http://localhost:4242"
+    expect( Compass.configuration.asset_host.call("ignored_by_lambda")).to eq "http://localhost:4242"
     expect( Compass.configuration.relative_assets ).to eq false 
   end
 


### PR DESCRIPTION
I noticed the Travis build was broken since it couldn't run the newest version of listen on the various JRuby profiles so I narrowed down the range for the gem.  Additionally there was one failing spec which passes now.