### PR TITLE
CSS Autoprefixer support

### DIFF
--- a/lib/awestruct/config/default-site.yml
+++ b/lib/awestruct/config/default-site.yml
@@ -17,7 +17,7 @@ content_syntax:
   ad: asciidoc
 
 haml:
-  :attr_wrapper: '"' 
+  :attr_wrapper: '"'
   :escape_attrs: :once
   :format: :xhtml
 
@@ -48,3 +48,6 @@ generation:
 profiles:
   development:
     show_drafts: true
+
+autoprefixer:
+  :browsers: ['> 1%', 'ie 10']

--- a/lib/awestruct/extensions/autoprefixer.rb
+++ b/lib/awestruct/extensions/autoprefixer.rb
@@ -1,0 +1,45 @@
+require 'autoprefixer-rails'
+
+module Awestruct
+  module Extensions
+    class AutoPrefixer
+      def initialize
+        if ExecJS.runtime.name.start_with? "therubyracer"
+          $LOG.warn "WARNING: ExecJS is using 'therubyracer' backend. " \
+            "My testing shows it usually deadlocking due to threaded " \
+            "execution here (tested with 0.12.3). " \
+            "AutoPrefixer and Awestruct coffee handler are both using " \
+            "ExecJS and there seems to be some concurrency issue with " \
+            "'therubyracer'. See " \
+            "https://github.com/sstephenson/execjs/issues/205"
+        end
+      end
+
+      def transform(site, page, input)
+        if page.output_extension == '.css'
+          fix_encoding(input)
+          input = AutoprefixerRails.process(
+            input,
+            from: page.source_path,
+            **site.autoprefixer
+          ).css
+        end
+        return input
+      end
+
+      # some files throw "An error occurred: "\xE2" from ASCII-8BIT to UTF-8" when
+      #   processed with ExecJS/nodejs backend like this one:
+      #   https://github.com/HubSpot/tether/blob/ad295ad/docs/css/intro.css
+      def fix_encoding(str)
+        if str.encoding == ::Encoding::ASCII_8BIT
+          f_enc = str.match(/\A@charset "([-A-Za-z0-9_]+)";/)
+          if f_enc && f_enc[1]
+            str.force_encoding(::Encoding.find(f_enc[1]))
+          else
+            str.force_encoding(::Encoding.default_external)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is adding Autoprefixer support which is required for using Bootstrap 4.

I think there is some bug with awestruct because I needed to write the
`fix_encoding` method. I found out that CSS files with non-ascii characters
seem to be loaded as ASCII_8BIT which later breaks the `Autoprefixer` execution.

This might be the case only when ExecJS is using Node.js backend. In any case
it would be better to handle this in awestruct core instead of in transformer.

That is because `therubyracer` backend is not reliable and deadlocks in threaded
environments. Please see https://github.com/sstephenson/execjs/issues/205