### PR TITLE
Make it possible to update Haml to version 5

### DIFF
--- a/awestruct.gemspec
+++ b/awestruct.gemspec
@@ -34,7 +34,7 @@ Haml and Markdown filters are touchy things. Redcarpet or Rdiscount work well if
 Compass and sass are no longer hard dependencies. You'll need too add them on your own should you want them. We also should be able to work with sassc.
   EOS
 
-  s.add_dependency 'haml', '~> 4.0', '>= 4.0.5'
+  s.add_dependency 'haml', '>= 4.0.5', '< 6.0'
   s.add_dependency 'asciidoctor', '~> 1.5', '>= 1.5.2'
   s.add_dependency 'tilt', '~> 2.0', '>= 2.0.1'
   s.add_dependency 'mime-types', '~> 3.0'

--- a/lib/awestruct/context_helper.rb
+++ b/lib/awestruct/context_helper.rb
@@ -40,10 +40,10 @@ module Awestruct
 
     def fully_qualify_urls(base_url, text)
       begin
-        doc = Oga.parse_html text
+        doc = Oga.parse_xml text
 
         doc.each_node do |elem|
-          if elem.is_a?(Oga::XML::Element) && elem.html?
+          if elem.is_a?(Oga::XML::Element)
             case elem.name
             when 'a'
               elem.set 'href', fix_url(base_url, elem.get('href')) if elem.get('href')


### PR DESCRIPTION
There were a couple of failures running the build from the master branch.

One commit relax the range for haml and the other one fix the build by changing slightly the ContextHelper#fully_qualify_urls

Not sure if it's the right approach, though