### PR TITLE
Return nonzero code also for syntax errors

### DIFF
--- a/lib/awestruct/engine.rb
+++ b/lib/awestruct/engine.rb
@@ -435,6 +435,7 @@ module Awestruct
           end
         rescue Exception => e
           Awestruct::ExceptionHelper.log_building_error e, page.relative_source_path
+          return Awestruct::ExceptionHelper::EXITCODES[:generation_error]
         ensure
           return Awestruct::ExceptionHelper::EXITCODES[:generation_error] if c.include? 'Backtrace:'
         end

--- a/spec/support/test-data/engine-generate-syntax-errors/_config/site.yml
+++ b/spec/support/test-data/engine-generate-syntax-errors/_config/site.yml
@@ -1,0 +1,26 @@
+profiles:
+  development:
+    show_drafts: false
+    cook: microwave
+    base_url: http://localhost:4242
+  production:
+    show_drafts: true
+    cook: oven
+    asciidoctor:
+      :eruby: erb
+      :attributes:
+        imagesdir: /img
+  staging:
+    compass_line_comments: off
+    compass_output_style: :compact
+    base_url: http://stage.example.com
+
+title: Awestruction!
+intl_name: Internéšnl
+
+asciidoctor:
+  :safe: 0
+  :eruby: erubis
+  :attributes:
+    imagesdir: /assets/images
+    idprefix: ''

--- a/spec/support/test-data/engine-generate-syntax-errors/_ext/pipeline.rb
+++ b/spec/support/test-data/engine-generate-syntax-errors/_ext/pipeline.rb
@@ -1,0 +1,8 @@
+require 'awestruct/extensions/pipeline'
+
+Awestruct::Extensions::Pipeline.new do
+  # extension Awestruct::Extensions::Posts.new '/news'
+  # extension Awestruct::Extensions::Indexifier.new
+  # Indexifier *must* come before Atomizer
+  # extension Awestruct::Extensions::Atomizer.new :posts, '/feed.atom'
+end

--- a/spec/support/test-data/engine-generate-syntax-errors/_layouts/base.html.slim
+++ b/spec/support/test-data/engine-generate-syntax-errors/_layouts/base.html.slim
@@ -1,0 +1,6 @@
+doctype html
+html
+  head
+    title Hello
+  body
+    = content

--- a/spec/support/test-data/engine-generate-syntax-errors/index.html.slim
+++ b/spec/support/test-data/engine-generate-syntax-errors/index.html.slim
@@ -1,0 +1,7 @@
+---
+layout: base
+---
+p#intentional-syntax-error
+  - if 2 > 4:
+     = 'hi'
+


### PR DESCRIPTION
If there is a syntax error in HAML, the return value  of `awestruct --generate` should be non-zero (important for CI builds).

Based on https://issues.jenkins-ci.org/browse/WEBSITE-469