### PR TITLE
Allow compiling with Ruby 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rvm:
   - 2.4.3
   - 2.5.0
   - 2.6.0
-  - jruby-9.1.0.0
+  - jruby-9.2.0.0
   - jruby-head
 jdk:
   - openjdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,27 +12,21 @@ rvm:
 jdk:
   - openjdk8
   - openjdk11
-  - oraclejdk8
+  - oraclejdk11
 matrix:
   exclude:
     - rvm: 2.4.3
       jdk: openjdk8
     - rvm: 2.4.3
       jdk: openjdk11
-    - rvm: 2.4.3
-      jdk: oraclejdk8
     - rvm: 2.5.0
       jdk: openjdk8
     - rvm: 2.5.0
       jdk: openjdk11
-    - rvm: 2.5.0
-      jdk: oraclejdk8
     - rvm: 2.6.0
       jdk: openjdk8
     - rvm: 2.6.0
       jdk: openjdk11
-    - rvm: 2.6.0
-      jdk: oraclejdk8
 
   allow_failures:
     - rvm: jruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rvm:
   - 2.4.3
   - 2.5.0
   - 2.6.0
-  - jruby-9.0.0.0
+  - jruby-9.1.0.0
   - jruby-head
 jdk:
   - openjdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rvm:
   - 2.4.3
   - 2.5.0
   - 2.6.0
-  - jruby-9.2.0.0
+  - jruby-9.2.7.0
   - jruby-head
 jdk:
   - openjdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,34 +4,36 @@ before_install:
   - gem install bundler
 language: ruby
 rvm:
-  - 2.0.0
-  - 2.1.0
-  - 2.2.0
-  - 2.2.1
+  - 2.4.3
+  - 2.5.0
+  - 2.6.0
   - jruby-9.0.0.0
   - jruby-head
 jdk:
-  - openjdk7
-  - oraclejdk7
+  - openjdk8
+  - openjdk11
   - oraclejdk8
 matrix:
   exclude:
-    - rvm: 2.0.0
+    - rvm: 2.4.3
+      jdk: openjdk8
+    - rvm: 2.4.3
+      jdk: openjdk11
+    - rvm: 2.4.3
       jdk: oraclejdk8
-    - rvm: 2.0.0
-      jdk: oraclejdk7
-    - rvm: 2.1.0
+    - rvm: 2.5.0
+      jdk: openjdk8
+    - rvm: 2.5.0
+      jdk: openjdk11
+    - rvm: 2.5.0
       jdk: oraclejdk8
-    - rvm: 2.1.0
-      jdk: oraclejdk7
-    - rvm: 2.2.0
+    - rvm: 2.6.0
+      jdk: openjdk8
+    - rvm: 2.6.0
+      jdk: openjdk11
+    - rvm: 2.6.0
       jdk: oraclejdk8
-    - rvm: 2.2.0
-      jdk: oraclejdk7
-    - rvm: 2.2.1
-      jdk: oraclejdk7
-    - rvm: 2.2.1
-      jdk: oraclejdk8
+
   allow_failures:
     - rvm: jruby-head
 notifications:

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '~> 2.4.0'
+ruby '>= 2.4.0'
 
 group :development do
   gem 'hashery', '~> 2.1.1'


### PR DESCRIPTION
Also updates list of Travis builds. JRuby <9.2 is not compatible with Ruby 2.4. I tried running 9.2.0.0 with Travis but got some errors with Java 11 unrelated to Awestruct, so I just bumped the version.