### PR TITLE
Parallel: don't override default

### DIFF
--- a/lib/awestruct/config/default-site.yml
+++ b/lib/awestruct/config/default-site.yml
@@ -42,8 +42,7 @@ asciidoctor:
 textile:
   :no_span_caps: true
 
-generation:
-  :in_threads: <%= Parallel.processor_count * 10 %>
+generation: {}
 
 profiles:
   development:


### PR DESCRIPTION
So far I know about 3 sites that updated from 0.5.7 to 0.6.0 alpha, all of them had problems related to the parallel setting and the build time was not improved (in case of Jenkins website it got significantly worse). Removing the setting means the default of `parallel` gem will be used (use `processor_count` processes in most cases).

Fixes #526