### PR TITLE
Allow --init without framework

### DIFF
--- a/lib/awestruct/cli/init.rb
+++ b/lib/awestruct/cli/init.rb
@@ -19,7 +19,7 @@ module Awestruct
         mkdir('stylesheets')
       }
 
-      def initialize(dir = Dir.pwd, framework = 'compass', scaffold = true)
+      def initialize(dir = Dir.pwd, framework = 'none', scaffold = true)
         @dir = dir
         @framework = framework
         @scaffold = scaffold

--- a/lib/awestruct/frameworks/none/base_index.html.haml
+++ b/lib/awestruct/frameworks/none/base_index.html.haml
@@ -1,0 +1,29 @@
+---
+layout: base
+---
+.jumbotron
+  %h1 You're awestruct!
+  %p This site is all setup to Awestruct.
+  %p
+    %a.btn.btn-primary.btn-lg{ :href=>'http://awestruct.org', :role=>"button" }
+      %i.icon-info-sign.icon-white
+      Learn more &raquo;
+
+.container-fluid
+  .row
+    .col-md-4
+      %h2 About
+      %p Awestruct is a framework for creating static HTML sites. It's inspired by the awesome Jekyll utility in the same genre.
+      %p Additionally, Awestruct integrates technologies such as Compass, Markdown and Haml.
+      %p
+        %a.btn{ :href=>'http://awestruct.org' } View details &raquo;
+    .col-md-4
+      %h2 Goal
+      %p The goal of Awestruct is to make it trivially easy to bake out non-trivial static websites. In addition to providing template-driven site creation (using Haml), Awestruct provides facilities for easily priming the site creation with additional non-page data.
+      %p
+        %a.btn{ :href=>'http://awestruct.org' } View details &raquo;
+    .col-md-4
+      %h2 Concept
+      %p The core concept of Awestruct is that of structures, specifically Ruby OpenStruct structures. The struct aspect allows arbitrary, schema-less data to be associated with a specific page or the entire site.
+      %p
+        %a.btn{ :href=>'http://awestruct.org' } View details &raquo;

--- a/lib/awestruct/frameworks/none/base_layout.html.haml
+++ b/lib/awestruct/frameworks/none/base_layout.html.haml
@@ -26,4 +26,3 @@
         %p &copy; #{site.org} #{Date.today.year}
     -# Uncomment script tags (remove leading -#) when you're ready to use behaviors
     -# %script{ :type=>'text/javascript', :src=>'//cdnjs.cloudflare.com/ajax/libs/jquery/1.9.1/jquery.min.js' }
-    -# %script{ :type=>'text/javascript', :src=>"#{site.base_url}/javascripts/bootstrap-collapse.js" }

--- a/spec/awestruct/cli/init_spec.rb
+++ b/spec/awestruct/cli/init_spec.rb
@@ -11,6 +11,10 @@ describe Awestruct::CLI::Init do
     FileUtils.rm_rf 'spec/support/clean_init'
   end
 
+  it "should not fail during init without framework" do
+    init = Awestruct::CLI::Init.new('spec/support/clean_init')
+    expect(init.run).to eql true
+  end
   it "should not fail during init with foundation" do
     init = Awestruct::CLI::Init.new('spec/support/clean_init', 'foundation', true)
     expect(init.run).to eql true


### PR DESCRIPTION
By default `awestruct --init` should not depend on `compass` framework.