### PR TITLE
Enable bundler caching for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: false
-
+cache: bundler
 before_install:
   - gem install bundler
 language: ruby


### PR DESCRIPTION
Would be interested to know why bundler cache hasn't been enabled on Travis. Thank you.