### PR TITLE
Log fatal exceptions in invoker.rb

### DIFF
--- a/lib/awestruct/cli/invoker.rb
+++ b/lib/awestruct/cli/invoker.rb
@@ -84,7 +84,9 @@ module Awestruct
           else
             true
           end
-        rescue
+        rescue => e
+          $LOG.fatal "Caught exception; exiting"
+          $LOG.fatal e
           @success = false
           false
         end


### PR DESCRIPTION
Otherwise such exception simply results in Awestruct returning status code 255 with no further details, which is hardly actionable.